### PR TITLE
Default extra_float_digits to 3 to preserve IEEE754 float fidelity

### DIFF
--- a/spec/pg/connection_spec.cr
+++ b/spec/pg/connection_spec.cr
@@ -10,51 +10,51 @@ end
 
 describe PG::Connection, "#exec untyped" do
   it "returns a Result" do
-    res = DB.exec("select 1")
+    res = $DB.exec("select 1")
     res.class.should eq(PG::Result(Array(PG::PGValue)))
   end
 
   it "raises on bad queries" do
-    expect_raises(PG::ResultError) { DB.exec("select nocolumn from notable") }
+    expect_raises(PG::ResultError) { $DB.exec("select nocolumn from notable") }
   end
 
   it "returns a Result when create table" do
-    res = DB.exec("create table if not exists test()")
+    res = $DB.exec("create table if not exists test()")
     res.class.should eq(PG::Result(Array(PG::PGValue)))
-    DB.exec("drop table test")
+    $DB.exec("drop table test")
   end
 end
 
 describe PG::Connection, "#exec typed" do
   it "returns a Result" do
-    res = DB.exec({Int32}, "select 1")
+    res = $DB.exec({Int32}, "select 1")
     res.class.should eq( PG::Result({Int32.class}) )
   end
 
   it "raises on bad queries" do
-    expect_raises(PG::ResultError) { DB.exec({Int32}, "select nocolumn from notable") }
+    expect_raises(PG::ResultError) { $DB.exec({Int32}, "select nocolumn from notable") }
   end
 end
 
 describe PG::Connection, "#exec typed with params" do
   it "returns a Result" do
-    res = DB.exec({Float64}, "select $1::float * $2::float ", [3.4, -2])
+    res = $DB.exec({Float64}, "select $1::float * $2::float ", [3.4, -2])
     res.class.should eq( PG::Result({Float64.class}) )
   end
 
   it "raises on bad queries" do
-    expect_raises(PG::ResultError) { DB.exec("select $1::text from notable", ["hello"]) }
+    expect_raises(PG::ResultError) { $DB.exec("select $1::text from notable", ["hello"]) }
   end
 end
 
 describe PG::Connection, "#exec untyped with params" do
   it "returns a Result" do
-    res = DB.exec("select $1::text, $2::text, $3::text", ["hello", "", "world"])
+    res = $DB.exec("select $1::text, $2::text, $3::text", ["hello", "", "world"])
     res.class.should eq(PG::Result(Array(PG::PGValue)))
   end
 
   it "raises on bad queries" do
-    expect_raises(PG::ResultError) { DB.exec("select $1::text from notable", ["hello"]) }
+    expect_raises(PG::ResultError) { $DB.exec("select $1::text from notable", ["hello"]) }
   end
 
   it "can properly encode various types" do
@@ -63,7 +63,7 @@ describe PG::Connection, "#exec untyped with params" do
     query = "select
              $1::text, $2::int, $3::text, $4::float, $5::timestamptz, $6::date, $7::bool"
     param =  ["hello",       2,    nil,    -4.23,      time,            date,       true]
-    res = DB.exec(query, param)
+    res = $DB.exec(query, param)
     res.rows.should eq([param])
   end
 

--- a/spec/pg/result_spec.cr
+++ b/spec/pg/result_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 macro test_decode(name, select, expected, file = __FILE__, line = __LINE__)
   it {{name}}, {{file}}, {{line}} do
-    rows = DB.exec("select #{{{select}}}").rows
+    rows = $DB.exec("select #{{{select}}}").rows
     rows.size.should eq( 1 )
     rows.first.size.should eq( 1 )
     rows.first.first.should eq( {{expected}} )
@@ -12,13 +12,13 @@ end
 describe PG::Result, "#fields" do
   it "is empty on empty results" do
     if Helper.db_version_gte(9,4)
-      fields = DB.exec("select").fields
+      fields = $DB.exec("select").fields
       fields.size.should eq(0)
     end
   end
 
   it "is is a list of the fields" do
-    fields = DB.exec("select 1 as one, 2 as two, 3 as three").fields
+    fields = $DB.exec("select 1 as one, 2 as two, 3 as three").fields
     fields.map(&.name).should eq(["one", "two", "three"])
     fields.map(&.oid).should eq([23,23,23])
   end
@@ -27,14 +27,14 @@ end
 describe PG::Result, "#rows" do
   it "is an empty 2d array on empty results" do
     if Helper.db_version_gte(9,4)
-      rows = DB.exec("select").rows
+      rows = $DB.exec("select").rows
       rows.size.should    eq(1)
       rows[0].size.should eq(0)
     end
   end
 
   it "can handle several types and several rows" do
-    rows = DB.exec(
+    rows = $DB.exec(
              {String, PG::NilableString, Bool, Int32},
              "select 'a', 'b', true, 22 union all select '', null, false, 53"
            ).rows
@@ -78,7 +78,7 @@ end
 
 describe PG::Result, "#to_hash" do
   it "represents the rows and fields as a hash" do
-    res = DB.exec("select 'a' as foo, 'b' as bar, true as baz, 1.0 as uhh
+    res = $DB.exec("select 'a' as foo, 'b' as bar, true as baz, 1.0 as uhh
                    union all
                    select '', null, false, -3.2")
     res.to_hash.should eq([
@@ -88,7 +88,7 @@ describe PG::Result, "#to_hash" do
   end
 
   it "raises if there are columns with the same name" do
-    res = DB.exec("select 'a' as foo, 'b' as foo, 'c' as bar")
+    res = $DB.exec("select 'a' as foo, 'b' as foo, 'c' as bar")
     expect_raises { res.to_hash }
   end
 end

--- a/spec/pg/result_spec.cr
+++ b/spec/pg/result_spec.cr
@@ -55,6 +55,9 @@ describe PG::Result, "#rows" do
   test_decode "integer",        "1",              1
   test_decode "float",          "-0.123::float",  -0.123
 
+  test_decode "double prec.",   "'35.03554004971999'::float8", 35.03554004971999
+  test_decode "flot prec.",     "'0.10000122'::float4", 0.10000122_f32
+
   if Helper.db_version_gte(9,2)
     test_decode "json",  "'[1,\"a\",true]'::json", [1, "a", true]
     test_decode "json",  "'{\"a\":1}'::json",      {"a" => 1}

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,11 +2,11 @@ require "spec"
 require "../src/pg"
 
 DB_URL = ENV["DATABASE_URL"]? || "postgres:///"
-DB = PG.connect(DB_URL)
+$DB = PG.connect(DB_URL)
 
 module Helper
   def self.db_version_gte(major, minor, patch=0)
-    ver = DB.version
+    ver = $DB.version
     ver[:major] >= major && ver[:minor] >= minor && ver[:patch] >= patch
   end
 end

--- a/src/pg.cr
+++ b/src/pg.cr
@@ -3,6 +3,8 @@ require "./pg/*"
 
 module PG
   def self.connect(conninfo)
-    Connection.new(conninfo)
+    conn = Connection.new(conninfo)
+    conn.exec("SET extra_float_digits = 3")
+    conn
   end
 end


### PR DESCRIPTION
The `extra_float_digits` setting must be at least `2` when reading 64-bit floats (and `3` for 32-bit floats) from Postgres to ensure that fidelity is preserved for all values (i.e., client and server are talking about the exact same bits).

As the Postgres community likes to point out, this is only meaningful for when both client and server have IEEE754 floating point implementations, but come on...

This is not ready to merge because of a spec failure, but I'm not sure if this is due to some issue in my patch, crystal-pg, or in crystal itself. The [semantically-equivalent test passes in pq](https://github.com/lib/pq/blob/master/conn_test.go#L845-L862). Any ideas?