### PR TITLE
exec_all method to allow multiple requests

### DIFF
--- a/spec/pg/connection_spec.cr
+++ b/spec/pg/connection_spec.cr
@@ -70,6 +70,17 @@ describe PG::Connection, "#exec untyped with params" do
   end
 end
 
+describe PG::Connection, "#exec_all" do
+  it "returns a Result" do
+    res = DB.exec_all("select 1; select 2;")
+    res.class.should eq( Nil )
+  end
+
+  it "raises on bad queries" do
+    expect_raises(PG::ResultError) { DB.exec_all("select 1; select nocolumn from notable;") }
+  end
+end
+
 describe PG::Connection, "#escape_literal" do
   assert { DB.escape_literal(%(foo)).should eq(%('foo')) }
   assert { DB.escape_literal(%(some"thing)).should eq(%('some\"thing')) }

--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -26,6 +26,11 @@ module PG
       Result.new(types, libpq_exec(query, params))
     end
 
+    def exec_all(query: String)
+      res = LibPQ.exec(raw, query)
+      check_status(res)
+    end
+
     def finish
       LibPQ.finish(raw)
       @raw = nil


### PR DESCRIPTION
This simple method allow to run multiple requests at once.

Useful when loading SQL files (migrations)