### PR TITLE
Allows typed querying when to_hash method is used in query results

### DIFF
--- a/spec/pg/result_spec.cr
+++ b/spec/pg/result_spec.cr
@@ -48,6 +48,17 @@ describe PG::Result, "#to_hash" do
     ])
   end
 
+  it "represents the rows and fields as a hash with typed querying" do
+    res = DB.exec({String, String, Bool, Int32},
+                  "select 'a' as foo, 'b' as bar, true as baz, 10 as uhh
+                   union all
+                   select '', 'c', false, 20")
+    res.to_hash.should eq([
+      {"foo" => "a", "bar" => "b", "baz" => true,  "uhh" => 10},
+      {"foo" => "",  "bar" => "c", "baz" => false, "uhh" => 20}
+    ])
+  end
+
   it "raises if there are columns with the same name" do
     res = DB.exec("select 'a' as foo, 'b' as foo, 'c' as bar")
     expect_raises { res.to_hash }

--- a/src/pg/result.cr
+++ b/src/pg/result.cr
@@ -34,7 +34,7 @@ module PG
       end
 
       rows.map do |row|
-        Hash.zip(field_names, row)
+        Hash.zip(field_names, row.to_a)
       end
     end
 


### PR DESCRIPTION
Hi, I tried to use:
```crystal
    DB.exec({String, String, Bool, Int32},
                  "select 'a' as foo, 'b' as bar, true as baz, 10 as uhh
                   union all
                   select '', 'c', false, 20").to_hash
```

Gives the next error:
```
instantiating 'PG::Result({Int32:Class, String:Class, String:Class, String:Class})#to_hash()'

    connect {|db| user = db.exec({Int32, String, String, String}, 
                                          ^~~~~~~

in ./libs/pg/pg/result.cr:37: no overload matches 'Hash(K, V)::zip' with types Array(String), {Int32, String, String, String}
Overloads are:
 - Hash(K, V)::zip(ary1 : Array(K), ary2 : Array(V))

        Hash.zip(field_names, row)
```

This PR solves the previous problem.