### PR TITLE
Crystal 0.8.0 compatibility

### DIFF
--- a/spec/pg/result_spec.cr
+++ b/spec/pg/result_spec.cr
@@ -31,7 +31,7 @@ describe PG::Result, "#rows" do
            ).rows
     rows.should eq([{"a", "b", true,  22},
                     {"",  nil, false, 53}])
-    [rows[0][0],    rows[1][0]].map(&.length).sum.should eq(1)
+    [rows[0][0],    rows[1][0]].map(&.size).sum.should eq(1)
     (rows[0][2] && !rows[1][2]).should be_true
     (rows[0][3] <   rows[1][3]).should be_true
   end

--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -52,7 +52,7 @@ module PG
     # Note that it is not necessary nor correct to do escaping when a data
     # value is passed as a separate parameter in `#exec`
     def escape_literal(str)
-      escaped = LibPQ.escape_literal(raw, str, str.length)
+      escaped = LibPQ.escape_literal(raw, str, str.size)
       extract_escaped_result(escaped)
     end
 
@@ -63,7 +63,7 @@ module PG
     # identifier might contain upper case characters whose case should be
     # preserved.
     def escape_identifier(str)
-      escaped = LibPQ.escape_identifier(raw, str, str.length)
+      escaped = LibPQ.escape_identifier(raw, str, str.size)
       extract_escaped_result(escaped)
     end
 

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -109,14 +109,14 @@ module PG
     class DateDecoder < Decoder
       def decode(value_ptr)
         v = swap32(value_ptr).to_i32
-        Time.new(JAN_1_2K_TICKS + (TimeSpan::TicksPerDay * v), kind: Time::Kind::Utc)
+        Time.new(JAN_1_2K_TICKS + (Time::Span::TicksPerDay * v), kind: Time::Kind::Utc)
       end
     end
 
     class TimeDecoder < Decoder
       def decode(value_ptr)
         v = swap64(value_ptr).to_i64 / 1000
-        Time.new(JAN_1_2K_TICKS + (TimeSpan::TicksPerMillisecond * v), kind: Time::Kind::Utc)
+        Time.new(JAN_1_2K_TICKS + (Time::Span::TicksPerMillisecond * v), kind: Time::Kind::Utc)
       end
     end
 


### PR DESCRIPTION
Crystal 0.8.0 changed a few things:

- `length` was removed, in favor to `size`
- `TimeSpan` was renamed as `Time::Span`