### PR TITLE
Iterate rows and fields from results

### DIFF
--- a/src/core_ext/class.cr
+++ b/src/core_ext/class.cr
@@ -1,5 +1,0 @@
-class Class
-  macro def as_cast(other) : self
-    other as self
-  end
-end

--- a/src/pg.cr
+++ b/src/pg.cr
@@ -1,4 +1,3 @@
-require "./core_ext/*"
 require "./pg/*"
 
 module PG

--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -146,7 +146,7 @@ module PG
                 status == LibPQ::ExecStatusType::PGRES_SINGLE_TUPLE ||
                 status == LibPQ::ExecStatusType::PGRES_COMMAND_OK)
       error = ResultError.new(res, status)
-      Result.clear_res(res)
+      LibPQ.clear(res)
       raise error
     end
 

--- a/src/pg/result.cr
+++ b/src/pg/result.cr
@@ -72,7 +72,7 @@ module PG
       {% for n in (from..to) %}
         private def gather_rows(types : Tuple({% for i in (1...n) %}Class, {% end %} Class))
           Array.new(ntuples) do |i|
-            { {% for j in (0...n) %} types[{{j}}].as_cast( decode_value(res,i,{{j}}) ), {% end %} }
+            { {% for j in (0...n) %} types[{{j}}].cast( decode_value(res,i,{{j}}) ), {% end %} }
           end
         end
       {% end %}

--- a/src/pg/result.cr
+++ b/src/pg/result.cr
@@ -1,5 +1,16 @@
 module PG
   class Result(T)
+    struct Row
+      def initialize(@result, @row)
+      end
+
+      def each
+        @result.fields.each_with_index do |field, col|
+          yield field.name, @result.decode_value(@row, col)
+        end
+      end
+    end
+
     struct Field
       property name
       property oid
@@ -24,6 +35,10 @@ module PG
 
     def finalize
       LibPQ.clear(res)
+    end
+
+    def each
+      ntuples.times { |i| yield Row.new(self, i) }
     end
 
     def fields


### PR DESCRIPTION
This allows to map a PG result to a struct or class, avoiding temporary memory structures (ie. Tuples and Hashes). I use this pattern extensively and would love to see it merged.

To achieve this, I keep a reference to the LibPQ::PGResult structure and delay the resolution of the rows and fields gatherer to be on demand. Actually only the rows have to, since fields is used by the iterator.