### PR TITLE
Event loop

### DIFF
--- a/src/core_ext/scheduler.cr
+++ b/src/core_ext/scheduler.cr
@@ -1,0 +1,7 @@
+class Scheduler
+  def self.create_resume_event_on_read(fiber : Fiber, fd : Int)
+    @@eb.new_event(fd, LibEvent2::EventFlags::Read, fiber) do |s, flags, data|
+      (data as Fiber).resume
+    end
+  end
+end

--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -179,12 +179,12 @@ module PG
         return
       end
 
-      # TODO: add a timeout (?)
-      read_event = @read_event ||= Scheduler.create_resume_event_on_read(Fiber.current, LibPQ.socket(raw))
+      # NOTE: no memoization: fiber is likely to change
+      read_event = Scheduler.create_resume_event_on_read(Fiber.current, LibPQ.socket(raw))
       read_event.add
-
-      # FIXME: will sometimes never resume the fiber
       Scheduler.reschedule
+    ensure
+      read_event.free if read_event
     end
 
     private def check_status(res, clear_results = false)

--- a/src/pg/libpq.cr
+++ b/src/pg/libpq.cr
@@ -47,6 +47,19 @@ module PG
     fun getlength = PQgetlength(res : PGresult, row_number : Int, column_number : Int) : Int
     fun getisnull = PQgetisnull(res : PGresult, row_number : Int, column_number : Int) : Bool
 
+    fun socket = PQsocket(conn : PGconn) : Int
+    fun send_query = PQsendQuery(conn : PGconn, query : CStr) : Int
+    fun send_query_params = PQsendQueryParams(
+                                   conn : PGconn,
+                                   query : CStr,
+                                   n_params : Int,
+                                   param_types : Oid*,
+                                   param_values : CStr*,
+                                   param_lengths : Int*,
+                                   param_formats : Int*,
+                                   result_format : Int) : Int
+    fun get_result = PQgetResult(conn : PGconn) : PGresult
+
     fun freemem = PQfreemem(ptr : Void*) : Void
   end
 end

--- a/src/pg/libpq.cr
+++ b/src/pg/libpq.cr
@@ -60,6 +60,9 @@ module PG
                                    result_format : Int) : Int
     fun get_result = PQgetResult(conn : PGconn) : PGresult
 
+    fun consume_input = PQconsumeInput(conn : PGconn) : Int
+    fun is_busy = PQisBusy(conn : PGconn) : Int
+
     fun freemem = PQfreemem(ptr : Void*) : Void
   end
 end


### PR DESCRIPTION
I noticed that PG::Connection#exec was blocking the event loop. I followed http://www.postgresql.org/docs/9.3/static/libpq-async.html page, hacked a few things and... it actually worked.

Here is an example, which prints `done (i)` on the screen every second when the connection is evented. instead of waiting for `i` seconds between each prints:

```crystal
require "pg"

DB_URL = ENV["DATABASE_URL"]? || "postgres:///"

5.times do |i|
  spawn do
    db = PG.connect(DB_URL)
    db.exec("SELECT pg_sleep(#{i});")
    puts "done (#{i})"
  end
end

sleep
```

I pushed the pull request for feedback. It seems to be working fine, specs are passing, and the above test too. I verified we can execute multiple queries from the same coroutine (one after another) but executing queries to a single connection from different coroutines eventually raises an "another command is already in progress" error.