### PR TITLE
Next crystal

### DIFF
--- a/spec/pg/result_spec.cr
+++ b/spec/pg/result_spec.cr
@@ -66,7 +66,9 @@ describe PG::Result, "#to_hash" do
 end
 
 struct FooBarBaz
-  property foo, bar, baz
+  property foo : String?
+  property bar : Bool?
+  property baz : Int32?
 
   def initialize(@foo, @bar, @baz)
   end

--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -4,7 +4,7 @@ require "../core_ext/scheduler"
 module PG
   class Connection
     # :nodoc:
-    record Param, slice, format do # Internal wrapper to represent an encoded parameter
+    record Param, slice : Slice(UInt8), format : Int32 do # Internal wrapper to represent an encoded parameter
       delegate to_unsafe, slice
       delegate size, slice
 

--- a/src/pg/error.cr
+++ b/src/pg/error.cr
@@ -10,7 +10,7 @@ module PG
   end
 
   class ResultError < Error
-    def initialize(raw_result, @status)
+    def initialize(raw_result, @status : LibPQ::ExecStatusType)
       msg = String.new(LibPQ.result_error_message(raw_result))
       super(msg)
     end

--- a/src/pg/result.cr
+++ b/src/pg/result.cr
@@ -15,7 +15,7 @@ module PG
       property name
       property oid
 
-      def initialize(@name, @oid)
+      def initialize(@name : String, @oid : Int32)
       end
 
       def self.new_from_res(res, col)
@@ -30,7 +30,7 @@ module PG
       end
     end
 
-    def initialize(@types : T, @res)
+    def initialize(@types : T, @res : LibPQ::PGresult)
     end
 
     def finalize

--- a/src/pg/result.cr
+++ b/src/pg/result.cr
@@ -1,7 +1,7 @@
 module PG
   class Result(T)
-    struct Row
-      def initialize(@result, @row)
+    struct Row(T)
+      def initialize(@result : PG::Result(T), @row : Int32)
       end
 
       def each
@@ -42,13 +42,13 @@ module PG
     end
 
     def fields
-      @fields ||= Array.new(nfields) do |i|
+      Array.new(nfields) do |i|
         Field.new_from_res(res, i)
       end
     end
 
     def rows
-      @rows ||= gather_rows(@types)
+      gather_rows(@types)
     end
 
     def any?


### PR DESCRIPTION
I'm having trouble with some of the changes for the new stuff in https://github.com/crystal-lang/crystal/pull/2443

I don't think `@read_event` is ever set in @ysbaddaden 's https://github.com/will/crystal-pg/pull/31 so commenting it out in https://github.com/will/crystal-pg/commit/1f52767eccca43fd3b4b14fd31bb8a41aa9eeae1 works

Other than that though, I've been stuck on a few cases with `crystal spec` and was wondering if @asterite or anyone could spare a few minutes. 

The two things so far:

- currently getting the types for `@rows` in result.cr
- before that the `fields[col].decoder.decode(val_ptr.to_slice(size))` line was complaining that a `fields[col]` was returning procs, but that isn't happening for me right now, also it doesn't return procs :/. That may have just been some other error I lost when I started over.