### PR TITLE
Add missing `true` in PQ::Connection#handle_async_frames

### DIFF
--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -143,6 +143,7 @@ module PQ
         true
       elsif frame.is_a?(Frame::NotificationResponse)
         handle_notification frame
+        true
       elsif frame.is_a?(Frame::NoticeResponse)
         handle_notice frame
         true


### PR DESCRIPTION
Adds a missing `true`. It works without it too, but it's just coincidence. `handle_notification` returns `Void`, and right now it's considered truthy. I plan to make some changes to `Void` and without this fix this code breaks.