### PR TITLE
Add property Geo types. Implements #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ correct results for `pg_config --includedir` and `pg_config --libdir`.
 - numeric/decimal (1)
 - varchar
 - regtype
-- geo types: point, box, path, lseg, polygon, circle, line (2)
+- geo types: point, box, path, lseg, polygon, circle, line
 
 1: A note on numeric: In postgres this type has arbitrary percision. In this
     driver, it is represented as a `PG::Numeric` which retians all precision, but
@@ -92,7 +92,6 @@ correct results for `pg_config --includedir` and `pg_config --libdir`.
     float first. If you need true abitrary percision, you can optionally
     require `pg_ext/big_rational` which adds `#to_big_r`, but requires that you
     have LibGMP installed.
-2: Not included by default, use `PG::Decoders.register_geo` to use
 
 
 ## Connection Pooling

--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -73,14 +73,12 @@ describe PG::Decoders do
   test_decode "bpchar", %('c'::char(5)), "c    "
   test_decode "name", %('hi'::name), "hi"
   test_decode "oid", %(2147483648::oid), 2147483648_u32
-
-  PG::Decoders.register_geo
-  test_decode "point", "'(1.2,3.4)'::point", {1.2, 3.4}
-  test_decode "line ", "'(1,2,3,4)'::line ", {1, -1, 1}
-  test_decode "line ", "'1,2,3'::circle   ", {1, 2, 3}
-  test_decode "lseg ", "'(1,2,3,4)'::lseg ", { {1, 2}, {3, 4} }
-  test_decode "box  ", "'(1,2,3,4)'::box  ", { {3, 4}, {1, 2} }
-  test_decode "path ", "'(1,2,3,4)'::path ", {:closed, [{1, 2}, {3, 4}]}
-  test_decode "path ", "'[1,2,3,4,5,6]'::path", {:open, [{1, 2}, {3, 4}, {5, 6}]}
-  test_decode "polygon", "'1,2,3,4,5,6'::polygon", [{1, 2}, {3, 4}, {5, 6}]
+  test_decode "point", "'(1.2,3.4)'::point", PG::Geo::Point.new(1.2, 3.4)
+  test_decode "line ", "'(1,2,3,4)'::line ", PG::Geo::Line.new(1.0, -1.0, 1.0)
+  test_decode "line ", "'1,2,3'::circle   ", PG::Geo::Circle.new(1.0, 2.0, 3.0)
+  test_decode "lseg ", "'(1,2,3,4)'::lseg ", PG::Geo::LineSegment.new(1.0, 2.0, 3.0, 4.0)
+  test_decode "box  ", "'(1,2,3,4)'::box  ", PG::Geo::Box.new(3.0, 4.0, 1.0, 2.0)
+  test_decode "path ", "'(1,2,3,4)'::path ", PG::Geo::Path.new([PG::Geo::Point.new(1.0, 2.0), PG::Geo::Point.new(3.0, 4.0)], closed: true)
+  test_decode "path ", "'[1,2,3,4,5,6]'::path", PG::Geo::Path.new([PG::Geo::Point.new(1.0, 2.0), PG::Geo::Point.new(3.0, 4.0), PG::Geo::Point.new(5.0, 6.0)], closed: false)
+  test_decode "polygon", "'1,2,3,4,5,6'::polygon", [PG::Geo::Point.new(1.0, 2.0), PG::Geo::Point.new(3.0, 4.0), PG::Geo::Point.new(5.0, 6.0)]
 end

--- a/src/pg/geo.cr
+++ b/src/pg/geo.cr
@@ -1,0 +1,21 @@
+module PG::Geo
+  record Point, x : Float64, y : Float64
+  record Line, a : Float64, b : Float64, c : Float64
+  record Circle, x : Float64, y : Float64, radius : Float64
+  record LineSegment, x1 : Float64, y1 : Float64, x2 : Float64, y2 : Float64
+  record Box, x1 : Float64, y1 : Float64, x2 : Float64, y2 : Float64
+
+  struct Path
+    getter points
+    getter? closed
+
+    def initialize(@points : Array(Point), @closed : Bool)
+    end
+
+    def open?
+      !closed?
+    end
+  end
+
+  alias Polygon = Array(Point)
+end


### PR DESCRIPTION
I decided to add types for things whose representation if the same, for example Box and LIneSegment, mostly because they represent different things, and one could imagine adding different methods to them. The same applies to Line and Circle. For Path I couldn't use `record` because I needed a query method (`closed?`), I'll think how we can make `record` do that automatically.