### PR TITLE
segfault maybe in spec framework?

### DIFF
--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -67,6 +67,15 @@ describe PG::Decoders do
     x.call("nan").nan?.should be_true
   end
 
+  test_decode "array", "ARRAY[1]", [1]
+  test_decode "array", "ARRAY[1,2]", [1,2]
+  test_decode "array", "ARRAY[ARRAY[9,8],ARRAY[7,6]] ", [[1,2],[3,4]]
+  test_decode "array", "'{{{1,2},{3,3}},{{2,5},{4,3}}}'::integer[]", [[1,2],[3,4]]
+  exit
+  test_decode "array", "ARRAY[1, null] ", [1, nil]
+  test_decode "array", "('[10:12]={1,2,3}'::integer[])", 10
+#  test_decode "int array ", "ARRAY[1,2,3,4,5,6,7]", [1, 2, 3, 4, 5, 6, 7]
+
   test_decode "xml", "'<json>false</json>'::xml", "<json>false</json>"
   test_decode "char", %('c'::"char"), 'c'
   test_decode "bpchar", %('c'::char), "c"


### PR DESCRIPTION
Very strange thing here @asterite ,  it looks like it might not be in the my code but in the spec framework. I'm nowhere near sure though, I could be very mistaken.

Printing the hexdump with a particular offset triggers the segfault. Any other offset, and the segfault doesn't happen. But the segfault is not happening during the hexdump, as other prints happen. It looks like it's happening when gathering the `#inspect` for the error messages. 


```
F
[36, 16]
[1, false, 23, [{dim: 2, lbound: 1}]]
Slice[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 2]
0000 0004 0000 0001 0000 0004 0000 0002  ................
Slice[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 2]
ok
Invalid memory access (signal 11) at address 0x0
[4337667195] *CallStack::print_backtrace:Int32 +107
[4337596263] __crystal_sigfault_handler +55
[140735510512938] _sigtramp +26
[4339653361] GC_generic_malloc_many +560
[4339681858] GC_malloc_atomic +132
[4337579899] __crystal_malloc_atomic +11
[4337719657] *GC::malloc_atomic<UInt32>:Pointer(Void) +9
[4337682213] *String::Builder#initialize<Int32>:Bool +37
[4337682154] *String::Builder::new<Int32>:String::Builder +138
[4337678625] *Array(Int32)@Object#inspect:String +33
[4338464745] *Spec::EqualExpectation(Array(Int32))@Spec::EqualExpectation(T)#failure_message<Array(Int32)>:String +41
[4337680255] *Array(Int32)@Spec::ObjectExtensions#should<Spec::EqualExpectation(Array(Int32)), String, Int32>:Nil +63
[4337644720] ~proc10Proc(Nil)@./spec/pg/decoder_spec.cr:4 +400
[4337625895] *it<String, String, Int32, &Proc(Nil)>:(Array(Spec::Result) | Nil) +391
[4338260175] */Users/will/code/crystal-pg/spec/pg/decoder_spec.cr#test_decode<String, String, Array(Int32), String, Int32>:(Array(Spec::Result) | Nil) +111
[4337624424] ~procProc(Nil)@./spec/pg/decoder_spec.cr:12 +3272
[4337918477] *Spec::RootContext::describe<String, String, Int32, &Proc(Nil)>:Spec::Context+ +365
[4337621091] *describe<PG::Decoders:Module, String, Int32, &Proc(Nil)>:Spec::Context+ +51
[4337540998] __crystal_main +4374
[4337595912] main +40
```

The `[4315101473] *Array(Int32)@Object#inspect:String +33` line changes type with whatever the return of `decode` is. For example changing the return to a string array shows `*Array(String)@Object#inspect` instead.

Sorry I don't have a better handle on this before grabbing your attention.