### PR TITLE
update to db unprepared statements

### DIFF
--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -11,7 +11,11 @@ module PG
       @connection.connect
     end
 
-    def build_statement(query)
+    def build_prepared_statement(query)
+      Statement.new(self, query)
+    end
+
+    def build_unprepared_statement(query)
       Statement.new(self, query)
     end
 


### PR DESCRIPTION
From https://github.com/crystal-lang/crystal-db/pull/25 (currently in master but not released) a connection will create prepared and non prepared statements. This is required for uniform transactions api.

It seems crystal-pg has only implemented non prepared statements so the quick solution is to reuse them when ever a prepared statement is expected.

Prepared statements have special treatment since they need the be released as opposed to non prepared ones.

I would vouch for a proper prepared statement in postgres, but I am not sure you will agree.