### PR TITLE
Update crystal-db to 0.3.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,4 @@ version: 0.12.0
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.2.2
+    version: ~> 0.3.0


### PR DESCRIPTION
For my [purpose](https://github.com/topaz-crystal/topaz), could you update the db version to 0.3.0?