### PR TITLE
Enable connection pool

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,4 @@ version: 0.12.0
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.3.0
+    version: ~> 0.3.1

--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,4 @@ version: 0.12.0
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.3.1
+    version: ~> 0.3.2

--- a/spec/pg/connection_spec.cr
+++ b/spec/pg/connection_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 describe PG::Connection, "#initialize" do
   it "raises on bad connections" do
-    expect_raises(PQ::ConnectionError) {
+    expect_raises(DB::ConnectionRefused) {
       DB.open("postgres://localhost:5433")
     }
   end

--- a/spec/pq/authentication_methods_spec.cr
+++ b/spec/pq/authentication_methods_spec.cr
@@ -17,7 +17,7 @@ describe PQ::Connection, "nologin role" do
   it "raises" do
     PG_DB.exec("drop role if exists crystal_test")
     PG_DB.exec("create role crystal_test nologin")
-    expect_raises(PQ::PQError) {
+    expect_raises(DB::ConnectionRefused) {
       DB.open("postgres://crystal_test@localhost")
     }
     PG_DB.exec("drop role if exists crystal_test")
@@ -39,11 +39,11 @@ if File.exists?(File.join(File.dirname(__FILE__), "../.run_auth_specs"))
       PG_DB.exec("drop role if exists crystal_md5")
       PG_DB.exec("create role crystal_md5 login encrypted password 'pass'")
 
-      expect_raises(PQ::PQError) {
+      expect_raises(DB::ConnectionRefused) {
         DB.open(other_role(":bad"))
       }
 
-      expect_raises(PQ::PQError) {
+      expect_raises(DB::ConnectionRefused) {
         DB.open(other_role(""))
       }
 

--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -9,6 +9,8 @@ module PG
       conn_info = PQ::ConnInfo.new(database.uri)
       @connection = PQ::Connection.new(conn_info)
       @connection.connect
+    rescue
+      raise DB::ConnectionRefused.new
     end
 
     def build_prepared_statement(query)

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -47,6 +47,8 @@ class PG::ResultSet < ::DB::ResultSet
       @end = true
       false
     end
+  rescue IO::EOFError
+    raise DB::ConnectionLost.new(statement.connection)
   end
 
   def column_count : Int32
@@ -80,6 +82,8 @@ class PG::ResultSet < ::DB::ResultSet
     end
 
     value
+  rescue IO::EOFError
+    raise DB::ConnectionLost.new(statement.connection)
   end
 
   def read(t : Array(T).class) : Array(T) forall T
@@ -106,6 +110,8 @@ class PG::ResultSet < ::DB::ResultSet
     ensure
       @column_index += 1
     end
+  rescue IO::EOFError
+    raise DB::ConnectionLost.new(statement.connection)
   end
 
   private def field(index = @column_index)

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -47,7 +47,7 @@ class PG::ResultSet < ::DB::ResultSet
       @end = true
       false
     end
-  rescue IO::EOFError
+  rescue IO::Error
     raise DB::ConnectionLost.new(statement.connection)
   end
 
@@ -82,7 +82,7 @@ class PG::ResultSet < ::DB::ResultSet
     end
 
     value
-  rescue IO::EOFError
+  rescue IO::Error
     raise DB::ConnectionLost.new(statement.connection)
   end
 
@@ -110,7 +110,7 @@ class PG::ResultSet < ::DB::ResultSet
     ensure
       @column_index += 1
     end
-  rescue IO::EOFError
+  rescue IO::Error
     raise DB::ConnectionLost.new(statement.connection)
   end
 
@@ -126,6 +126,8 @@ class PG::ResultSet < ::DB::ResultSet
     col_size = conn.read_i32
     conn.skip_bytes(col_size) if col_size != 1
     @column_index += 1
+  rescue IO::Error
+    raise DB::ConnectionLost.new(statement.connection)
   end
 
   protected def do_close
@@ -149,5 +151,8 @@ class PG::ResultSet < ::DB::ResultSet
 
       break unless move_next
     end
+  rescue DB::ConnectionLost
+    # if the connection is lost there is nothing to be
+    # done since the result set is no longer needed
   end
 end

--- a/src/pg/statement.cr
+++ b/src/pg/statement.cr
@@ -27,6 +27,8 @@ class PG::Statement < ::DB::Statement
       raise "expected RowDescription or NoData, got #{frame}"
     end
     ResultSet.new(self, fields)
+  rescue IO::EOFError
+    raise DB::ConnectionLost.new(connection)
   end
 
   protected def perform_exec(args : Enumerable) : ::DB::ExecResult
@@ -36,5 +38,7 @@ class PG::Statement < ::DB::Statement
       rows_affected: result.rows_affected,
       last_insert_id: 0_i64 # postgres doesn't support this
     )
+  rescue IO::EOFError
+    raise DB::ConnectionLost.new(connection)
   end
 end


### PR DESCRIPTION
This PR enables the connection pooling from crystal-db to work with crystal-pg.

In order for the connection pool to work `DB::ConnectionLost` and `DB::ConnectionRefused` need to be raised when executing commands or establishing connections.

This also requires to crystal-db ~> ~~0.3.1~~ 0.3.2 

the fix for `pq/authentication_methods_spec.cr` could be different, those specs uses `/pg/*` so now the exception to expect need to be `DB::ConnectionLost` and `DB::ConnectionRefused`.

cc: @raydf 

