### PR TITLE
ensure listen/notify spec works in same connection

### DIFF
--- a/spec/pg/connection_spec.cr
+++ b/spec/pg/connection_spec.cr
@@ -34,14 +34,16 @@ describe PG::Connection, "#on_notice" do
 end
 
 describe PG::Connection, "#on_notification" do
-  it "does listen/notify" do
+  it "does listen/notify within same connection" do
     last_note = nil
-    PG_DB.using_connection do |conn|
-      conn.on_notification { |note| last_note = note }
-    end
+    with_db do |db|
+      db.using_connection do |conn|
+        conn.on_notification { |note| last_note = note }
 
-    PG_DB.exec("listen somechannel")
-    PG_DB.exec("notify somechannel, 'do a thing'")
+        conn.exec("listen somechannel")
+        conn.exec("notify somechannel, 'do a thing'")
+      end
+    end
 
     last_note.not_nil!.channel.should eq("somechannel")
     last_note.not_nil!.payload.should eq("do a thing")


### PR DESCRIPTION
While working on crystal-lang/crystal-db#35 I notice that the following spec will break.
This PR fixes things beforehand and it also make sense today.

~~I will send a related PR to discuss listen/notify across other connections.~~ see #79
The former spec worked only because the same connection was been used for listen & notify. 