### PR TITLE
allow listen/notify to work from different connections

### DIFF
--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -41,7 +41,7 @@ module PG
       @connection.notification_handler = on_notification_proc
     end
 
-    protected def listen(*channels : String)
+    def listen(*channels : String)
       channels.each { |c| exec_all "LISTEN #{escape_identifier c}" }
       listen
     end


### PR DESCRIPTION
Right now, there is no clear way to use listen/notify from different connections.

Given a `PG::Connection` there is no way to reach the (protected) `#listen()` method that will spawn a call to `#read_async_frame_loop`.

This PR turns `#listen(*channels : String)` public. It is the minimal change to allow the new spec to pass.

I would go with an implementation that use/add `#listen(*channels : String)` `#unlisten(*channels : String)` to track whether the connection should have an spawned fiber to process the notifications. The `#unlisten` should stop de spawned fiber probably when it is no longer needed.

I am not sure how that impact with notifications received via `Frame::NotificationResponse`

So, rather a full PR this open a discussion + offers a minimal implementation to deal with  listen/notify from different connections.
