### PR TITLE
Support for Crystal 0.21.0

### DIFF
--- a/spec/pg/escape_helper_spec.cr
+++ b/spec/pg/escape_helper_spec.cr
@@ -1,18 +1,18 @@
 require "../spec_helper"
 
 describe PG::Connection, "#escape_literal" do
-  assert { escape_literal(%(foo)).should eq(%('foo')) }
-  assert { escape_literal(%(this has a \\)).should eq(%( E'this has a \\\\')) }
-  assert { escape_literal(%(what's your "name")).should eq(%('what''s your "name"')) }
-  assert { escape_literal(%(foo).to_slice).should eq(%('\\x666f6f')) }
+  it { escape_literal(%(foo)).should eq(%('foo')) }
+  it { escape_literal(%(this has a \\)).should eq(%( E'this has a \\\\')) }
+  it { escape_literal(%(what's your "name")).should eq(%('what''s your "name"')) }
+  it { escape_literal(%(foo).to_slice).should eq(%('\\x666f6f')) }
   # it "raises on invalid strings" do
   #  expect_raises(PG::ConnectionError) { escape_literal("\u{F4}") }
   # end
 end
 
 describe PG::Connection, "#escape_identifier" do
-  assert { escape_identifier(%(foo)).should eq(%("foo")) }
-  assert { escape_identifier(%(what's \\ your "name")).should eq(%("what's \\ your ""name""")) }
+  it { escape_identifier(%(foo)).should eq(%("foo")) }
+  it { escape_identifier(%(what's \\ your "name")).should eq(%("what's \\ your ""name""")) }
   # it "raises on invalid strings" do
   #  expect_raises(PG::ConnectionError) { escape_identifier("\u{F4}") }
   # end

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -1,5 +1,5 @@
 require "uri"
-require "crypto/md5"
+require "digest/md5"
 require "socket"
 require "socket/tcp_socket"
 require "socket/unix_socket"
@@ -254,14 +254,14 @@ module PQ
     end
 
     private def handle_auth_md5(salt)
-      inner = Crypto::MD5.hex_digest("#{@conninfo.password}#{@conninfo.user}")
+      inner = Digest::MD5.hexdigest("#{@conninfo.password}#{@conninfo.user}")
 
-      c = Crypto::MD5::Context.new
-      c.update(inner.to_unsafe, inner.bytesize.to_u32)
-      c.update(salt.to_unsafe, salt.bytesize.to_u32)
-      c.final
+      pass = Digest::MD5.hexdigest do |ctx|
+        ctx.update(inner.to_unsafe, inner.bytesize.to_u32)
+        ctx.update(salt.to_unsafe, salt.bytesize.to_u32)
+      end
 
-      send_password_message "md5#{c.hex}"
+      send_password_message "md5#{pass}"
       expect_frame Frame::Authentication
     end
 


### PR DESCRIPTION
1. `assert` is now `it`
2. `Crypto::MD5` is now `Digest::MD5`