### PR TITLE
Use vm based ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,26 @@ dist: trusty
 
 sudo: required
 
-addons:
-  postgresql: "9.4"
+services:
+  - postgresql
 
 language: crystal
+
 crystal:
   - latest
+
 env:
+  - TRAVIS_POSTGRESQL_VERSION=9.6
+  - TRAVIS_POSTGRESQL_VERSION=9.5
   - TRAVIS_POSTGRESQL_VERSION=9.4
   - TRAVIS_POSTGRESQL_VERSION=9.3
   - TRAVIS_POSTGRESQL_VERSION=9.2
-  - TRAVIS_POSTGRESQL_VERSION=9.1
+
 before_install:
   - sudo service postgresql stop
   - sudo service postgresql start $TRAVIS_POSTGRESQL_VERSION
   - createdb crystal
   - export DATABASE_URL=postgres://postgres@/crystal
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+dist: trusty
+
+sudo: required
+
 addons:
   postgresql: "9.4"
+
 language: crystal
 crystal:
   - latest
@@ -8,11 +13,10 @@ env:
   - TRAVIS_POSTGRESQL_VERSION=9.3
   - TRAVIS_POSTGRESQL_VERSION=9.2
   - TRAVIS_POSTGRESQL_VERSION=9.1
-before_install: |
-  sudo service postgresql stop
-  sudo service postgresql start $TRAVIS_POSTGRESQL_VERSION
-  createdb crystal
-  export DATABASE_URL=postgres://postgres@localhost/crystal
+before_install:
+  - sudo service postgresql stop
+  - sudo service postgresql start $TRAVIS_POSTGRESQL_VERSION
+  - createdb crystal
+  - export DATABASE_URL=postgres://postgres@localhost/crystal
 notifications:
   email: false
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ before_install:
   - sudo service postgresql stop
   - sudo service postgresql start $TRAVIS_POSTGRESQL_VERSION
   - createdb crystal
-  - export DATABASE_URL=postgres://postgres@localhost/crystal
+  - export DATABASE_URL=postgres://postgres@/crystal
 notifications:
   email: false

--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -65,8 +65,10 @@ describe PG::Decoders do
   test_decode "name", %('hi'::name), "hi"
   test_decode "oid", %(2147483648::oid), 2147483648_u32
   test_decode "point", "'(1.2,3.4)'::point", PG::Geo::Point.new(1.2, 3.4)
-  test_decode "line ", "'(1,2,3,4)'::line ", PG::Geo::Line.new(1.0, -1.0, 1.0)
-  test_decode "line ", "'1,2,3'::circle   ", PG::Geo::Circle.new(1.0, 2.0, 3.0)
+  if Helper.db_version_gte(9, 4)
+    test_decode "line ", "'(1,2,3,4)'::line ", PG::Geo::Line.new(1.0, -1.0, 1.0)
+    test_decode "line ", "'1,2,3'::circle   ", PG::Geo::Circle.new(1.0, 2.0, 3.0)
+  end
   test_decode "lseg ", "'(1,2,3,4)'::lseg ", PG::Geo::LineSegment.new(1.0, 2.0, 3.0, 4.0)
   test_decode "box  ", "'(1,2,3,4)'::box  ", PG::Geo::Box.new(1.0, 2.0, 3.0, 4.0)
   test_decode "path ", "'(1,2,3,4)'::path ", PG::Geo::Path.new([PG::Geo::Point.new(1.0, 2.0), PG::Geo::Point.new(3.0, 4.0)], closed: true)

--- a/spec/pg/encoder_spec.cr
+++ b/spec/pg/encoder_spec.cr
@@ -24,7 +24,9 @@ describe PG::Driver, "encoder" do
   test_insert_and_read "integer[]", [1, 2, 3]
   test_insert_and_read "integer[]", [[1, 2], [3, 4]]
   test_insert_and_read "point", PG::Geo::Point.new(1.2, 3.4)
-  test_insert_and_read "line", PG::Geo::Line.new(1.2, 3.4, 5.6)
+  if Helper.db_version_gte(9, 4)
+    test_insert_and_read "line", PG::Geo::Line.new(1.2, 3.4, 5.6)
+  end
   test_insert_and_read "circle", PG::Geo::Circle.new(1.2, 3.4, 5.6)
   test_insert_and_read "lseg", PG::Geo::LineSegment.new(1.2, 3.4, 5.6, 7.8)
   test_insert_and_read "box", PG::Geo::Box.new(1.2, 3.4, 5.6, 7.8)


### PR DESCRIPTION
+ I've noticed that `crystal-pg` was using `postgresql` **9.4** libraries on all tests suites (even when specified `9.1`), so I change to **sudo-based**
+ I use socket connections instead of IP based, due to an travis error (I think) => reported
https://github.com/travis-ci/travis-ci/issues/7449
+ I add test env using `postgresql `**9.5** / **9.6**

PS : 
Travis feature
~~~yaml
addons
~~~
is deprecated https://docs.travis-ci.com/user/addons/