### PR TITLE
Per-connection decoders with PoC `citext` and `hstore` support

### DIFF
--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -38,6 +38,18 @@ describe PG::Decoders do
     test_decode "jsonb", "'[1,2,3]'::jsonb", JSON.parse("[1,2,3]")
   end
 
+  it "citext" do
+    begin
+      PG_DB.exec("CREATE EXTENSION \"citext\"")
+      with_connection do |conn| # fresh connection so decoders are evaluated
+        value = conn.query_one "select 'abc'::citext", &.read
+        value.should eq("abc")
+      end
+    ensure
+      PG_DB.exec("DROP EXTENSION \"citext\"")
+    end
+  end
+
   test_decode "timestamptz", "'2015-02-03 16:15:13-01'::timestamptz",
     Time.new(2015, 2, 3, 17, 15, 13, 0, Time::Kind::Utc)
 

--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -40,19 +40,19 @@ describe PG::Decoders do
 
   it "citext" do
     begin
-      PG_DB.exec("CREATE EXTENSION \"citext\"")
+      PG_DB.exec("CREATE EXTENSION IF NOT EXISTS \"citext\"")
       with_connection do |conn| # fresh connection so decoders are evaluated
         value = conn.query_one "select 'abc'::citext", &.read
         value.should eq("abc")
       end
     ensure
-      PG_DB.exec("DROP EXTENSION \"citext\"")
+      PG_DB.exec("DROP EXTENSION IF EXISTS \"citext\"")
     end
   end
 
   it "hstore" do
     begin
-      PG_DB.exec("CREATE EXTENSION \"hstore\"")
+      PG_DB.exec("CREATE EXTENSION IF NOT EXISTS \"hstore\"")
       with_connection do |conn| # fresh connection so decoders are evaluated
         value = conn.query_one "select 'foo=>bar,baz=>42'::hstore", &.read
         value.should eq({"foo" => "bar", "baz" => "42"})
@@ -67,7 +67,7 @@ describe PG::Decoders do
         value.should eq(nil)
       end
     ensure
-      PG_DB.exec("DROP EXTENSION \"hstore\"")
+      PG_DB.exec("DROP EXTENSION IF EXISTS \"hstore\"")
     end
   end
 

--- a/spec/pg/encoder_spec.cr
+++ b/spec/pg/encoder_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 private def test_insert_and_read(datatype, value, extension = nil, file = __FILE__, line = __LINE__)
   it "inserts #{datatype}", file, line do
     begin
-      PG_DB.exec "create extension \"#{extension}\"" if extension
+      PG_DB.exec "create extension if not exists \"#{extension}\"" if extension
 
       with_connection do |conn|
         conn.exec "drop table if exists test_table"
@@ -19,7 +19,7 @@ private def test_insert_and_read(datatype, value, extension = nil, file = __FILE
         actual_value.should eq(value)
       end
     ensure
-      PG_DB.exec "drop extension \"#{extension}\" cascade" if extension
+      PG_DB.exec "drop extension if exists \"#{extension}\" cascade" if extension
     end
   end
 end

--- a/spec/pg/encoder_spec.cr
+++ b/spec/pg/encoder_spec.cr
@@ -29,6 +29,7 @@ describe PG::Driver, "encoder" do
   test_insert_and_read "float", 12.34
   test_insert_and_read "varchar", "hello world"
   test_insert_and_read "citext", "hello world", extension: "citext"
+  test_insert_and_read "hstore", {"foo" => "42", "bar" => nil}, extension: "hstore"
   test_insert_and_read "integer[]", [] of Int32
   test_insert_and_read "integer[]", [1, 2, 3]
   test_insert_and_read "integer[]", [[1, 2], [3, 4]]

--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -57,6 +57,10 @@ module PG
       {major: major, minor: minor, patch: patch}
     end
 
+    def decoders
+      @decoders ||= Hash(Int32, PG::Decoders::Decoder).new { |_, oid| Decoders.from_oid(oid) }
+    end
+
     protected def do_close
       @connection.close
     end

--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -14,17 +14,17 @@ module PG
         conn_info = PQ::ConnInfo.new(context.uri)
         @connection = PQ::Connection.new(conn_info)
         @connection.connect
-
-        # We have to query `pg_type` table to learn about the types in this
-        # database, so make sure we temporarily set `auto_release` to false
-        # else this would cause a premature `release` before this connection
-        # has even been added to the pool.
-        self.auto_release, auto_release = false, self.auto_release
-        @decoders = Decoders.build_decoder_list(self)
-        self.auto_release = auto_release
       rescue
         raise DB::ConnectionRefused.new
       end
+
+      # We have to query `pg_type` table to learn about the types in this
+      # database, so make sure we temporarily set `auto_release` to false
+      # else this would cause a premature `release` before this connection
+      # has even been added to the pool.
+      self.auto_release, auto_release = false, self.auto_release
+      @decoders = Decoders.build_decoder_list(self)
+      self.auto_release = auto_release
     end
 
     def build_prepared_statement(query)

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -302,12 +302,7 @@ module PG
     end
 
     TYPE_SQL = %q(
-      SELECT
-        /* Avoid search_path woes by qualifying before cast... */
-        (typnamespace::regnamespace::text || '.' || typname)::regtype::oid
-                                              oid
-      , typname                               "name"
-      , typcategory                           category
+      SELECT oid, typname, typcategory
       FROM pg_type
       WHERE typisdefined = 't'
         AND typtype IN ('b', 'd'))

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -139,7 +139,7 @@ module PG
             length = read_u32(io)
             key = string_decoder.decode(io, length)
             length = read_u32(io)
-            if length == UInt32::MAX
+            if length == -1
               hash[key] = nil
             else
               value = string_decoder.decode(io, length)

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -300,6 +300,8 @@ module PG
       @@decoders[oid]
     end
 
+    # Globally registers a `Decoder` instance to handle type specified by
+    # provided OID.
     def self.register_decoder(decoder, oid)
       @@decoders[oid] = decoder
     end

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -119,7 +119,7 @@ class PG::ResultSet < ::DB::ResultSet
   end
 
   private def decoder(index = @column_index)
-    statement.connection.decoders[field(index).type_oid]
+    statement.connection.decoder_from_oid(field(index).type_oid)
   end
 
   private def skip

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -119,7 +119,7 @@ class PG::ResultSet < ::DB::ResultSet
   end
 
   private def decoder(index = @column_index)
-    Decoders.from_oid(field(index).type_oid)
+    statement.connection.decoders[field(index).type_oid]
   end
 
   private def skip

--- a/src/pq/param.cr
+++ b/src/pq/param.cr
@@ -22,6 +22,10 @@ module PQ
       text val.to_s(ISO_8601)
     end
 
+    def self.encode(val : Hash(String, String?))
+      text val.map { |k, v| "#{k.inspect} => #{v.nil? ? "NULL" : v.inspect}" }.join(',')
+    end
+
     def self.encode(val : PG::Geo::Point)
       text "(#{val.x},#{val.y})"
     end


### PR DESCRIPTION
This is a follow up to my thoughts in #88.

## Summary

Reading from a result set picks a decoder via a connection-local decoder map instead of the global list. Misses on the local map fallback to the existing global map of handlers.

When a connection is first initialised, it is immediately used to interrogate `pg_type` and expand on the statically-defined global decoder map.

This mechanism is used to implement `citext` support.

<details>
<summary>Notes</summary>

* This will cause types to be determined multiple types in a connection pooling scenario. It may instead be preferable to do this once per `DB`. However, given that connections may or may not be pooled, the current approach seemed the most prudent, at least from a proof-of-concept standpoint.
* Changes to the types during a connection won't be visible (e.g. `CREATE EXTENSION`). There's a few options here, but they don't seem deeply important to address now. It does mean the test for `citext` has to jump through some hoops, though.
* The statically-defined global map of decoder handlers is depended upon to interpret the result set from querying `pg_type`.
* I've left more comments and commented-out code than I usually would as the point of this PR is foremost to communicate the idea. E.g. A small snippet of code shows how a specialised `HstoreDecoder` could be wired up, too.

</details>