### PR TITLE
Patch to fix hanging on unhandled exceptions

### DIFF
--- a/spec/pg/driver_spec.cr
+++ b/spec/pg/driver_spec.cr
@@ -40,7 +40,6 @@ describe PG::Driver do
 
       result = PG_DB.query "insert into contacts values ($1)", "Foo"
       result = PG_DB.query "insert into contacts values ($1)", "Foo" do |rs|
-        pp rs
         rs.move_next
       end
     end

--- a/spec/pg/driver_spec.cr
+++ b/spec/pg/driver_spec.cr
@@ -33,6 +33,19 @@ describe PG::Driver do
     end
   end
 
+  it "should raise an exception if unique constraint is violated" do
+    expect_raises(PQ::PQError) do
+      PG_DB.exec "drop table if exists contacts"
+      PG_DB.exec "create table contacts (name varchar(256), CONSTRAINT key_name UNIQUE(name))"
+
+      result = PG_DB.query "insert into contacts values ($1)", "Foo"
+      result = PG_DB.query "insert into contacts values ($1)", "Foo" do |rs|
+        pp rs
+        rs.move_next
+      end
+    end
+  end
+
   it "executes insert" do
     PG_DB.exec "drop table if exists contacts"
     PG_DB.exec "create table contacts (name varchar(256), age int4)"

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -51,7 +51,7 @@ class PG::ResultSet < ::DB::ResultSet
     raise DB::ConnectionLost.new(statement.connection)
   rescue ex
     @end = true
-    raise ex.message
+    raise ex
   end
 
   def column_count : Int32

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -49,6 +49,9 @@ class PG::ResultSet < ::DB::ResultSet
     end
   rescue IO::Error
     raise DB::ConnectionLost.new(statement.connection)
+  rescue ex
+    @end = true
+    raise ex.message
   end
 
   def column_count : Int32


### PR DESCRIPTION
PG would hang indefinitely if an exception was raised, but not handled.  This is due to `@end` not being set to true when this occurs so while attempting to process the result_set it gets caught in an infinite loop.

Issues related can be seen at

https://github.com/will/crystal-pg/issues/98
https://github.com/crystal-lang/crystal-db/issues/46
https://github.com/Crecto/crecto/issues/76