### PR TITLE
Fix skipping null values

### DIFF
--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -127,7 +127,7 @@ class PG::ResultSet < ::DB::ResultSet
 
   private def skip
     col_size = conn.read_i32
-    conn.skip_bytes(col_size) if col_size != 1
+    conn.skip_bytes(col_size) if col_size != -1
     @column_index += 1
   rescue IO::Error
     raise DB::ConnectionLost.new(statement.connection)


### PR DESCRIPTION
crystal-pg would hang indefinitely or throw an error when there were unread null values.
The skip function didn't skip bytes when the column byte size was 1 but it should be -1 which is when it's null.

Fixes
https://github.com/will/crystal-pg/issues/102
https://github.com/crystal-lang/crystal-db/issues/59