### PR TITLE
#112 attempted fix

### DIFF
--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -267,6 +267,15 @@ module PQ
 
     def read_next_row_start
       type = soc.read_char
+
+      if type == 'N'
+        frame = read_one_frame type
+        async_frames = handle_async_frames frame
+        if async_frames
+          type = soc.read_char
+        end
+      end
+           
       if type == 'D'
         true
       else


### PR DESCRIPTION
I was having problems with RETURNING statements (like an INSERT returning the id of the created row) but it turned out that it was just a problem with async notifications breaking the flow as illustrated.

Basically, what I was getting was notices from a trigger function that happen on the insert. These appear before the DataRow that encapsulate the RETURNING.

Maybe this is a bit messy. But it works.

I suspect that there's a much better way of dealing with the async messages.