### PR TITLE
Update to use crystal-db ~> 0.5.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,4 @@ version: 0.14.0
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.4.1
+    version: ~> 0.5.0


### PR DESCRIPTION
Fixes #122 .
@will a new crystal-db was released for 0.24, no changes in the api.

I realized later that that bump was not really need. I'll try to be more careful next time.

