### PR TITLE
enable travis spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ notifications:
 
 script:
   - crystal tool format --check
+  - crystal spec


### PR DESCRIPTION
Somehow travis wasn't being used to run specs anymore.