### PR TITLE
Check connection client encoding is UTF8, case-insensitive

### DIFF
--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -207,7 +207,7 @@ module PQ
       @server_parameters[frame.key] = frame.value
       case frame.key
       when "client_encoding"
-        if frame.value != "UTF8"
+        if frame.value.upcase != "UTF8"
           raise ConnectionError.new(
             "Only UTF8 is supported for client_encoding, got: #{frame.value.inspect}")
         end


### PR DESCRIPTION
Fixes connections with encoding set as lowercase `utf8` as opposed to `UTF8` that still have compatible encoding.

Notably, this prevents an error being raised when using [PgBouncer](https://pgbouncer.github.io/) in Heroku for [client-side connection pooling](https://devcenter.heroku.com/articles/on-dyno-postgres-connection-pooling).