### PR TITLE
Enable clientcert authentication

### DIFF
--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,10 +1,43 @@
 set -e
 
 AUTH_FILE=`psql -U postgres -c "SHOW hba_file" -At`
+CONFIG_FILE=`psql -U postgres -c "SHOW config_file" -At`
 
 # md5 authentication
 
 sudo sed -i '1s/^/host	all	crystal_md5	127.0.0.1\/32	md5\n/' ${AUTH_FILE}
 sudo sed -i '2s/^/host	all	crystal_md5	::1\/128	md5\n/' ${AUTH_FILE}
+
+# ssl clientcert authentication
+
+sudo sed -i '3s/^/hostssl all crystal_ssl 127.0.0.1\/32 cert clientcert=1\n/' ${AUTH_FILE}
+
+mkdir ~/cert && cd ~/cert
+openssl req -new -nodes -text -out ca.csr -keyout ca-key.pem -subj "/CN=certificate-authority"
+openssl x509 -req -in ca.csr -text -extfile /etc/ssl/openssl.cnf -extensions v3_ca -signkey ca-key.pem -out ca-cert.pem
+openssl req -new -nodes -text -out server.csr -keyout server-key.pem -subj "/CN=pg-server"
+openssl x509 -req -in server.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem
+openssl req -new -nodes -text -out client.csr -keyout client-key.pem -subj "/CN=crystal_ssl"
+openssl x509 -req -in client.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out client-cert.pem
+chmod 600 *
+
+sudo mkdir -p /etc/ssl/postgresql/
+sudo cp ca-cert.pem server-cert.pem server-key.pem /etc/ssl/postgresql/
+sudo chmod 700 /etc/ssl/postgresql
+sudo chown -R postgres.postgres /etc/ssl/postgresql
+
+sudo sed -i "s/^ssl_cert_file = .*/ssl_cert_file = '\/etc\/ssl\/postgresql\/server-cert.pem'/" ${CONFIG_FILE}
+sudo sed -i "s/^ssl_key_file = .*/ssl_key_file = '\/etc\/ssl\/postgresql\/server-key.pem'/" ${CONFIG_FILE}
+sudo sed -i -r "s/^#?ssl_ca_file = .*/ssl_ca_file = '\/etc\/ssl\/postgresql\/ca-cert.pem'/" ${CONFIG_FILE}
+
+mkdir -p ~/.postgresql/
+cp client-cert.pem client-key.pem ca-cert.pem ~/.postgresql/
+cd ~/.postgresql/
+mv ca-cert.pem root.crt
+mv client-cert.pem crystal_ssl.crt
+mv client-key.pem crystal_ssl.key
+openssl verify -CAfile root.crt crystal_ssl.crt
+
+# restart service
 
 sudo service postgresql restart $TRAVIS_POSTGRESQL_VERSION

--- a/spec/pq/authentication_methods_spec.cr
+++ b/spec/pq/authentication_methods_spec.cr
@@ -9,8 +9,7 @@ require "../spec_helper"
 
 private def other_role(pass)
   db = PG_DB.query_one("select current_database()", &.read)
-  host = URI.parse(DB_URL).host || "localhost"
-  "postgres://crystal_md5#{pass}@#{host}/#{db}"
+  "postgres://crystal_md5:#{pass}@127.0.0.1/#{db}"
 end
 
 describe PQ::Connection, "nologin role" do
@@ -29,7 +28,7 @@ if File.exists?(File.join(File.dirname(__FILE__), "../.run_auth_specs"))
     it "works when given the correct password" do
       PG_DB.exec("drop role if exists crystal_md5")
       PG_DB.exec("create role crystal_md5 login encrypted password 'pass'")
-      DB.open(other_role(":pass")) do |db|
+      DB.open(other_role("pass")) do |db|
         db.query_one("select 1", &.read).should eq(1)
       end
       PG_DB.exec("drop role if exists crystal_md5")
@@ -40,7 +39,7 @@ if File.exists?(File.join(File.dirname(__FILE__), "../.run_auth_specs"))
       PG_DB.exec("create role crystal_md5 login encrypted password 'pass'")
 
       expect_raises(DB::ConnectionRefused) {
-        DB.open(other_role(":bad"))
+        DB.open(other_role("bad"))
       }
 
       expect_raises(DB::ConnectionRefused) {
@@ -48,6 +47,20 @@ if File.exists?(File.join(File.dirname(__FILE__), "../.run_auth_specs"))
       }
 
       PG_DB.exec("drop role if exists crystal_md5")
+    end
+  end
+
+  describe PQ::Connection, "ssl clientcert auth" do
+    it "works when using ssl clientcert" do
+      PG_DB.exec("drop role if exists crystal_ssl")
+      PG_DB.exec("create role crystal_ssl login encrypted password 'pass'")
+      db = PG_DB.query_one("select current_database()", &.read)
+      home = ENV["HOME"]
+      uri = "postgres://crystal_ssl@127.0.0.1/#{db}?sslmode=verify-full&sslcert=#{home}/.postgresql/crystal_ssl.crt&sslkey=#{home}/.postgresql/crystal_ssl.key&sslrootcert=#{home}/.postgresql/root.crt"
+      DB.open(uri) do |db|
+        db.query_one("select current_user", &.read).should eq("crystal_ssl")
+      end
+      PG_DB.exec("drop role if exists crystal_ssl")
     end
   end
 else

--- a/spec/pq/conninfo_spec.cr
+++ b/spec/pq/conninfo_spec.cr
@@ -20,6 +20,13 @@ private def assert_custom_params(ci)
   ci.sslmode.should eq(:require)
 end
 
+private def assert_ssl_params(ci)
+  ci.sslmode.should eq(:"verify-full")
+  ci.sslcert.should eq("postgresql.crt")
+  ci.sslkey.should eq("postgresql.key")
+  ci.sslrootcert.should eq("root.crt")
+end
+
 describe PQ::ConnInfo, "parts" do
   it "can have all defaults" do
     ci = PQ::ConnInfo.new
@@ -44,6 +51,10 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
     assert_custom_params ci
 
     ci = PQ::ConnInfo.from_conninfo_string(
+      "postgres://user:pass@host:5555/db?sslmode=verify-full&sslcert=postgresql.crt&sslkey=postgresql.key&sslrootcert=root.crt")
+    assert_ssl_params ci
+
+    ci = PQ::ConnInfo.from_conninfo_string(
       "postgresql://user:pass@host:5555/db?sslmode=require")
     assert_custom_params ci
   end
@@ -52,6 +63,10 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
     ci = PQ::ConnInfo.from_conninfo_string(
       "host=host dbname=db user=user password=pass port=5555 sslmode=require")
     assert_custom_params ci
+
+    ci = PQ::ConnInfo.from_conninfo_string(
+      "host=host dbname=db user=user password=pass port=5555 sslmode=verify-full sslcert=postgresql.crt sslkey=postgresql.key sslrootcert=root.crt")
+    assert_ssl_params ci
 
     ci = PQ::ConnInfo.from_conninfo_string("host=host")
     ci.host.should eq("host")

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -54,6 +54,15 @@ module PQ
       if serv_ssl
         ctx = OpenSSL::SSL::Context::Client.new
         ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE # currently emulating sslmode 'require' not verify_ca or verify_full
+        if sslcert = @conninfo.sslcert
+          ctx.certificate_chain = sslcert
+        end
+        if sslkey = @conninfo.sslkey
+          ctx.private_key = sslkey
+        end
+        if sslrootcert = @conninfo.sslrootcert
+          ctx.ca_certificates = sslrootcert
+        end
         @soc = OpenSSL::SSL::Socket::Client.new(@soc, context: ctx, sync_close: true)
       end
 


### PR DESCRIPTION
Allow clientcert authentication using query parameters that resemble the parameter key words (`sslcert`, `sslkey`, `sslrootcert`): https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS.