### PR TITLE
Upgrade to Crystal 0.28.0

### DIFF
--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -1,4 +1,5 @@
 require "uri"
+require "http"
 
 module PQ
   struct ConnInfo
@@ -97,7 +98,7 @@ module PQ
     end
 
     private def default_host(h)
-      return h if h
+      return h if h && !h.blank?
 
       SOCKET_SEARCH.each do |s|
         return s if File.exists?(s)


### PR DESCRIPTION
* URI#host is no longer nilable, checking for blank is required to return the right default host
* Add require to allow running spec/pq/conninfo_spec.cr in isolation

The change is backward compatible with Crystal 0.20 (and crystal-db 0.5 requires Crystal 0.24)