### PR TITLE
Surround call PQ::Connection#close with rescue

### DIFF
--- a/src/pg/connection.cr
+++ b/src/pg/connection.cr
@@ -56,7 +56,12 @@ module PG
     end
 
     protected def do_close
-      @connection.close
+      super
+
+      begin
+        @connection.close
+      rescue
+      end
     end
   end
 end


### PR DESCRIPTION
* The `PQ::Connection#close` might raise. `#do_close` should never raise
* A call to super to clean up resources was missing