### PR TITLE
Fix IOError on closed connection

### DIFF
--- a/src/pg/statement.cr
+++ b/src/pg/statement.cr
@@ -27,7 +27,7 @@ class PG::Statement < ::DB::Statement
       raise "expected RowDescription or NoData, got #{frame}"
     end
     ResultSet.new(self, fields)
-  rescue IO::EOFError
+  rescue IO::Error
     raise DB::ConnectionLost.new(connection)
   end
 
@@ -38,7 +38,7 @@ class PG::Statement < ::DB::Statement
       rows_affected: result.rows_affected,
       last_insert_id: 0_i64 # postgres doesn't support this
     )
-  rescue IO::EOFError
+  rescue IO::Error
     raise DB::ConnectionLost.new(connection)
   end
 end


### PR DESCRIPTION
If a closed connection is used in a query it will immediately exit with `IO::Error: Closed stream`. Since currently only `EOFError`s are rescued, a closed connection will be re-used in subsequent queries and will always fail.

Please let me know if this is not the correct fix for this or if there is another reason for using `IO::EOFError` and not the parent `IO::Error`.