### PR TITLE
Some array fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ work but are not guaranteed.
 - varchar
 - regtype
 - geo types: point, box, path, lseg, polygon, circle, line
-- array types: int8, int4, int2, float8, float4, bool, text
+- array types: int8, int4, int2, float8, float4, bool, text, numeric, timestamptz, date, timestamp
 
 1: A note on numeric: In Postgres this type has arbitrary precision. In this
     driver, it is represented as a `PG::Numeric` which retains all precision, but

--- a/spec/pg/decoders/array_decoder_spec.cr
+++ b/spec/pg/decoders/array_decoder_spec.cr
@@ -41,9 +41,27 @@ describe PG::Decoders do
     value.should be_nil
   end
 
+  it "reads arrray of numeric" do
+    value = PG_DB.query_one("select '{1,2,3}'::numeric[]", &.read(Array(PG::Numeric)))
+    typeof(value).should eq(Array(PG::Numeric))
+    value.map(&.to_f).should eq([1, 2, 3])
+  end
+
+  it "reads arrray of nilable numeric" do
+    value = PG_DB.query_one("select '{1,null,3}'::numeric[]", &.read(Array(PG::Numeric?)))
+    typeof(value).should eq(Array(PG::Numeric?))
+    value.map(&.try &.to_f).should eq([1, nil, 3])
+  end
+
   it "raises when reading null in non-null array" do
     expect_raises(PG::RuntimeError) do
       PG_DB.query_one("select '{1,2,3,null}'::integer[]", &.read(Array(Int32)))
+    end
+  end
+
+  it "raises when reading incorrect array type" do
+    expect_raises(PG::RuntimeError) do
+      PG_DB.query_one("select '{1,2,3}'::numeric[]", &.read(Array(Float64)))
     end
   end
 

--- a/spec/pg/numeric_spec.cr
+++ b/spec/pg/numeric_spec.cr
@@ -126,6 +126,7 @@ describe PG::Numeric do
       {"50093.60754417", "50093.60754417"},
     ].each do |x|
       ex(x[0]).to_s.should eq(x[1])
+      ex(x[0]).inspect.should eq(x[1])
     end
   end
 

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -6,7 +6,7 @@ module PG
   # :nodoc:
   module Decoders
     module Decoder
-      abstract def decode(io, bytesize)
+      abstract def decode(io, bytesize, oid)
       abstract def oids : Array(Int32)
       abstract def type
 
@@ -54,379 +54,30 @@ module PG
     struct StringDecoder
       include Decoder
 
+      UUID_OID = 2950
+
       def_oids [
-        19,   # name (internal type)
-        25,   # text
-        142,  # xml
-        705,  # unknown
-        1042, # blchar
-        1043, # varchar
+        19,       # name (internal type)
+        25,       # text
+        142,      # xml
+        705,      # unknown
+        1042,     # blchar
+        1043,     # varchar
+        UUID_OID, # uuid
       ]
 
-      def decode(io, bytesize)
+      def decode(io, bytesize, oid)
+        if oid == UUID_OID
+          return decode_uuid(io, bytesize)
+        end
+
         String.new(bytesize) do |buffer|
           io.read_fully(Slice.new(buffer, bytesize))
           {bytesize, 0}
         end
       end
 
-      def type
-        String
-      end
-    end
-
-    struct CharDecoder
-      include Decoder
-
-      def_oids [
-        18, # "char" (internal type)
-      ]
-
-      def decode(io, bytesize)
-        # TODO: can be done without creating an intermediate string
-        String.new(bytesize) do |buffer|
-          io.read_fully(Slice.new(buffer, bytesize))
-          {bytesize, 0}
-        end[0]
-      end
-
-      def type
-        Char
-      end
-    end
-
-    struct BoolDecoder
-      include Decoder
-
-      OIDS = [
-        16, # bool
-      ]
-
-      def decode(io, bytesize)
-        case byte = io.read_byte
-        when 0
-          false
-        when 1
-          true
-        else
-          raise "bad boolean decode: #{byte}"
-        end
-      end
-
-      def oids : Array(Int32)
-        OIDS
-      end
-
-      def type
-        Bool
-      end
-    end
-
-    struct Int16Decoder
-      include Decoder
-
-      def_oids [
-        21, # int2 (smallint)
-      ]
-
-      def decode(io, bytesize)
-        read_i16(io)
-      end
-
-      def type
-        Int16
-      end
-    end
-
-    struct Int32Decoder
-      include Decoder
-
-      def_oids [
-        23,   # int4 (integer)
-        2206, # regtype
-      ]
-
-      def decode(io, bytesize)
-        read_i32(io)
-      end
-
-      def type
-        Int32
-      end
-    end
-
-    struct Int64Decoder
-      include Decoder
-
-      def_oids [
-        20, # int8 (bigint)
-      ]
-
-      def decode(io, bytesize)
-        read_u64(io).to_i64
-      end
-
-      def type
-        Int64
-      end
-    end
-
-    struct UIntDecoder
-      include Decoder
-
-      def_oids [
-        26, # oid (internal type)
-      ]
-
-      def decode(io, bytesize)
-        read_u32(io)
-      end
-
-      def type
-        UInt32
-      end
-    end
-
-    struct Float32Decoder
-      include Decoder
-
-      def_oids [
-        700, # float4
-      ]
-
-      def decode(io, bytesize)
-        read_f32(io)
-      end
-
-      def type
-        Float32
-      end
-    end
-
-    struct Float64Decoder
-      include Decoder
-
-      def_oids [
-        701, # float8
-      ]
-
-      def decode(io, bytesize)
-        read_f64(io)
-      end
-
-      def type
-        Float64
-      end
-    end
-
-    struct PointDecoder
-      include Decoder
-
-      def_oids [
-        600, # point
-      ]
-
-      def decode(io, bytesize)
-        Geo::Point.new(read_f64(io), read_f64(io))
-      end
-
-      def type
-        Geo::Point
-      end
-    end
-
-    struct PathDecoder
-      include Decoder
-
-      def_oids [
-        602, # path
-      ]
-
-      def decode(io, bytesize)
-        byte = io.read_byte.not_nil!
-        closed = byte == 1_u8
-        Geo::Path.new(PolygonDecoder.new.decode(io, bytesize - 1).points, closed)
-      end
-
-      def type
-        Geo::Path
-      end
-    end
-
-    struct PolygonDecoder
-      include Decoder
-
-      def_oids [
-        604, # polygon
-      ]
-
-      def decode(io, bytesize)
-        c = read_u32(io)
-        count = (pointerof(c).as(Int32*)).value
-        points = Array.new(count) do |i|
-          PointDecoder.new.decode(io, 16)
-        end
-        Geo::Polygon.new(points)
-      end
-
-      def type
-        Geo::Polygon
-      end
-    end
-
-    struct BoxDecoder
-      include Decoder
-
-      def_oids [
-        603, # box
-      ]
-
-      def decode(io, bytesize)
-        x2, y2, x1, y1 = read_f64(io), read_f64(io), read_f64(io), read_f64(io)
-        Geo::Box.new(x1, y1, x2, y2)
-      end
-
-      def type
-        Geo::Box
-      end
-    end
-
-    struct LineSegmentDecoder
-      include Decoder
-
-      def_oids [
-        601, # lseg
-      ]
-
-      def decode(io, bytesize)
-        Geo::LineSegment.new(read_f64(io), read_f64(io), read_f64(io), read_f64(io))
-      end
-
-      def type
-        Geo::LineSegment
-      end
-    end
-
-    struct LineDecoder
-      include Decoder
-
-      def_oids [
-        628, # line
-      ]
-
-      def decode(io, bytesize)
-        Geo::Line.new(read_f64(io), read_f64(io), read_f64(io))
-      end
-
-      def type
-        Geo::Line
-      end
-    end
-
-    struct CircleDecoder
-      include Decoder
-
-      def_oids [
-        718, # circle
-      ]
-
-      def decode(io, bytesize)
-        Geo::Circle.new(read_f64(io), read_f64(io), read_f64(io))
-      end
-
-      def type
-        Geo::Circle
-      end
-    end
-
-    struct JsonDecoder
-      include Decoder
-
-      def_oids [
-        114, # json
-      ]
-
-      def decode(io, bytesize)
-        string = String.new(bytesize) do |buffer|
-          io.read_fully(Slice.new(buffer, bytesize))
-          {bytesize, 0}
-        end
-        JSON.parse(string)
-      end
-
-      def type
-        JSON::Any
-      end
-    end
-
-    struct JsonbDecoder
-      include Decoder
-
-      def_oids [
-        3802, # jsonb
-      ]
-
-      def decode(io, bytesize)
-        io.read_byte
-
-        string = String.new(bytesize - 1) do |buffer|
-          io.read_fully(Slice.new(buffer, bytesize - 1))
-          {bytesize - 1, 0}
-        end
-        JSON.parse(string)
-      end
-
-      def type
-        JSON::Any
-      end
-    end
-
-    JAN_1_2K = Time.utc(2000, 1, 1)
-
-    struct DateDecoder
-      include Decoder
-
-      def_oids [
-        1082, # date
-      ]
-
-      def decode(io, bytesize)
-        v = read_i32(io)
-        JAN_1_2K + Time::Span.new(days: v, hours: 0, minutes: 0, seconds: 0)
-      end
-
-      def type
-        Time
-      end
-    end
-
-    struct TimeDecoder
-      include Decoder
-
-      def_oids [
-        1114, # timestamp
-        1184, # timestamptz
-      ]
-
-      def decode(io, bytesize)
-        v = read_i64(io) # microseconds
-        sec, m = v.divmod(1_000_000)
-        JAN_1_2K + Time::Span.new(seconds: sec, nanoseconds: m*1000)
-      end
-
-      def type
-        Time
-      end
-    end
-
-    struct UuidDecoder
-      include Decoder
-
-      def_oids [
-        2950, # uuid
-      ]
-
-      def decode(io, bytesize)
+      private def decode_uuid(io, bytesize)
         bytes = uninitialized UInt8[6]
 
         String.new(36) do |buffer|
@@ -461,6 +112,326 @@ module PG
       end
     end
 
+    struct CharDecoder
+      include Decoder
+
+      def_oids [
+        18, # "char" (internal type)
+      ]
+
+      def decode(io, bytesize, oid)
+        # TODO: can be done without creating an intermediate string
+        String.new(bytesize) do |buffer|
+          io.read_fully(Slice.new(buffer, bytesize))
+          {bytesize, 0}
+        end[0]
+      end
+
+      def type
+        Char
+      end
+    end
+
+    struct BoolDecoder
+      include Decoder
+
+      OIDS = [
+        16, # bool
+      ]
+
+      def decode(io, bytesize, oid)
+        case byte = io.read_byte
+        when 0
+          false
+        when 1
+          true
+        else
+          raise "bad boolean decode: #{byte}"
+        end
+      end
+
+      def oids : Array(Int32)
+        OIDS
+      end
+
+      def type
+        Bool
+      end
+    end
+
+    struct Int16Decoder
+      include Decoder
+
+      def_oids [
+        21, # int2 (smallint)
+      ]
+
+      def decode(io, bytesize, oid)
+        read_i16(io)
+      end
+
+      def type
+        Int16
+      end
+    end
+
+    struct Int32Decoder
+      include Decoder
+
+      def_oids [
+        23,   # int4 (integer)
+        2206, # regtype
+      ]
+
+      def decode(io, bytesize, oid)
+        read_i32(io)
+      end
+
+      def type
+        Int32
+      end
+    end
+
+    struct Int64Decoder
+      include Decoder
+
+      def_oids [
+        20, # int8 (bigint)
+      ]
+
+      def decode(io, bytesize, oid)
+        read_u64(io).to_i64
+      end
+
+      def type
+        Int64
+      end
+    end
+
+    struct UIntDecoder
+      include Decoder
+
+      def_oids [
+        26, # oid (internal type)
+      ]
+
+      def decode(io, bytesize, oid)
+        read_u32(io)
+      end
+
+      def type
+        UInt32
+      end
+    end
+
+    struct Float32Decoder
+      include Decoder
+
+      def_oids [
+        700, # float4
+      ]
+
+      def decode(io, bytesize, oid)
+        read_f32(io)
+      end
+
+      def type
+        Float32
+      end
+    end
+
+    struct Float64Decoder
+      include Decoder
+
+      def_oids [
+        701, # float8
+      ]
+
+      def decode(io, bytesize, oid)
+        read_f64(io)
+      end
+
+      def type
+        Float64
+      end
+    end
+
+    struct PointDecoder
+      include Decoder
+
+      def_oids [
+        600, # point
+      ]
+
+      def decode(io, bytesize, oid)
+        Geo::Point.new(read_f64(io), read_f64(io))
+      end
+
+      def type
+        Geo::Point
+      end
+    end
+
+    struct PathDecoder
+      include Decoder
+
+      def_oids [
+        602, # path
+      ]
+
+      def decode(io, bytesize, oid)
+        byte = io.read_byte.not_nil!
+        closed = byte == 1_u8
+        Geo::Path.new(PolygonDecoder.new.decode(io, bytesize - 1, oid).points, closed)
+      end
+
+      def type
+        Geo::Path
+      end
+    end
+
+    struct PolygonDecoder
+      include Decoder
+
+      def_oids [
+        604, # polygon
+      ]
+
+      def decode(io, bytesize, oid)
+        c = read_u32(io)
+        count = (pointerof(c).as(Int32*)).value
+        points = Array.new(count) do |i|
+          PointDecoder.new.decode(io, 16, oid)
+        end
+        Geo::Polygon.new(points)
+      end
+
+      def type
+        Geo::Polygon
+      end
+    end
+
+    struct BoxDecoder
+      include Decoder
+
+      def_oids [
+        603, # box
+      ]
+
+      def decode(io, bytesize, oid)
+        x2, y2, x1, y1 = read_f64(io), read_f64(io), read_f64(io), read_f64(io)
+        Geo::Box.new(x1, y1, x2, y2)
+      end
+
+      def type
+        Geo::Box
+      end
+    end
+
+    struct LineSegmentDecoder
+      include Decoder
+
+      def_oids [
+        601, # lseg
+      ]
+
+      def decode(io, bytesize, oid)
+        Geo::LineSegment.new(read_f64(io), read_f64(io), read_f64(io), read_f64(io))
+      end
+
+      def type
+        Geo::LineSegment
+      end
+    end
+
+    struct LineDecoder
+      include Decoder
+
+      def_oids [
+        628, # line
+      ]
+
+      def decode(io, bytesize, oid)
+        Geo::Line.new(read_f64(io), read_f64(io), read_f64(io))
+      end
+
+      def type
+        Geo::Line
+      end
+    end
+
+    struct CircleDecoder
+      include Decoder
+
+      def_oids [
+        718, # circle
+      ]
+
+      def decode(io, bytesize, oid)
+        Geo::Circle.new(read_f64(io), read_f64(io), read_f64(io))
+      end
+
+      def type
+        Geo::Circle
+      end
+    end
+
+    struct JsonDecoder
+      include Decoder
+
+      JSONB_OID = 3802
+
+      def_oids [
+        114,       # json
+        JSONB_OID, # jsonb
+      ]
+
+      def decode(io, bytesize, oid)
+        if oid == JSONB_OID
+          io.read_byte
+          bytesize -= 1
+        end
+
+        string = String.new(bytesize) do |buffer|
+          io.read_fully(Slice.new(buffer, bytesize))
+          {bytesize, 0}
+        end
+        JSON.parse(string)
+      end
+
+      def type
+        JSON::Any
+      end
+    end
+
+    struct TimeDecoder
+      include Decoder
+
+      DATE_OID = 1082
+      JAN_1_2K = Time.utc(2000, 1, 1)
+
+      def_oids [
+        DATE_OID, # date
+        1114,     # timestamp
+        1184,     # timestamptz
+      ]
+
+      def decode(io, bytesize, oid)
+        if oid == DATE_OID
+          v = read_i32(io)
+          JAN_1_2K + Time::Span.new(days: v, hours: 0, minutes: 0, seconds: 0)
+        else
+          v = read_i64(io) # microseconds
+          sec, m = v.divmod(1_000_000)
+          JAN_1_2K + Time::Span.new(seconds: sec, nanoseconds: m*1000)
+        end
+      end
+
+      def type
+        Time
+      end
+    end
+
     struct ByteaDecoder
       include Decoder
 
@@ -468,7 +439,7 @@ module PG
         17, # bytea
       ]
 
-      def decode(io, bytesize)
+      def decode(io, bytesize, oid)
         slice = Bytes.new(bytesize)
         io.read_fully(slice)
         slice
@@ -486,7 +457,7 @@ module PG
         1700, # numeric
       ]
 
-      def decode(io, bytesize)
+      def decode(io, bytesize, oid)
         ndigits = read_i16(io)
         weight = read_i16(io)
         sign = read_i16(io)
@@ -522,13 +493,10 @@ module PG
     register_decoder Int64Decoder.new
     register_decoder UIntDecoder.new
     register_decoder JsonDecoder.new
-    register_decoder JsonbDecoder.new
     register_decoder Float32Decoder.new
     register_decoder Float64Decoder.new
-    register_decoder DateDecoder.new
     register_decoder TimeDecoder.new
     register_decoder NumericDecoder.new
-    register_decoder UuidDecoder.new
     register_decoder PointDecoder.new
     register_decoder LineSegmentDecoder.new
     register_decoder PathDecoder.new

--- a/src/pg/numeric.cr
+++ b/src/pg/numeric.cr
@@ -32,7 +32,7 @@ module PG
     # (not an array of individual digits!)
     getter digits : Array(Int16)
 
-    def initialize(@ndigits, @weight, sign, @dscale, @digits)
+    def initialize(@ndigits : Int16, @weight : Int16, sign, @dscale : Int16, @digits : Array(Int16))
       @sign = Sign.from_value(sign)
     end
 

--- a/src/pg/numeric.cr
+++ b/src/pg/numeric.cr
@@ -63,6 +63,10 @@ module PG
       neg? ? -quot : quot
     end
 
+    def inspect(io : IO)
+      to_s(io)
+    end
+
     def to_s(io : IO)
       if ndigits == 0
         if nan?

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -74,7 +74,7 @@ class PG::ResultSet < ::DB::ResultSet
     end
 
     safe_read(col_bytesize) do |io|
-      decoder.decode(io, col_bytesize)
+      decoder.decode(io, col_bytesize, oid)
     end
   rescue IO::Error
     raise DB::ConnectionLost.new(statement.connection)
@@ -125,7 +125,11 @@ class PG::ResultSet < ::DB::ResultSet
   end
 
   private def decoder(index = @column_index)
-    Decoders.from_oid(field(index).type_oid)
+    Decoders.from_oid(oid(index))
+  end
+
+  private def oid(index = @column_index)
+    field(index).type_oid
   end
 
   private def skip


### PR DESCRIPTION
Fixes #105
Fixes #172

There are several commits here:
1. If an exception happened while trying to decode an array we should have skipped the remaining bytes for that column. We already do that when reading something that's not an array, it was missing for an array. This was the reason for the hang up.
2. Let `Numeric#inspect` use `Numeric#to_s`, which all number types in Crystal do. Probably doesn't belong here but it made debugging things easier.
3. Previously you could decode an array of numeric as an array of float (you can print the value in #105 and you'll see garbage). So now we check that the correct array type is read.
4. A refactor so that each type maps univocally to a decoder. For example now there's a single `TimeDecoder` that deals with postgres dates and times. This commit allows reading array of Time (#172).

For point 3 I had to change the way decoders are registered: I needed to know their `oid` to compare it against the `oid` that we get from the array header. Then I needed the type they are decoding to to show a more useful error message.

@jwoertink Could you check whether this branch fixes your issue? Well, instead of a hang up you would get a runtime exception.