### PR TITLE
Use Slice#ready_fully in UUID decoder

### DIFF
--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -58,6 +58,12 @@ describe PG::Decoders do
     x.call("nan").nan?.should be_true
   end
 
+  it "decodes many uuids (#148)" do
+    uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    ids = PG_DB.query_all("select '#{uuid}'::uuid from generate_series(1,1000)", as: String)
+    ids.uniq.should eq([uuid])
+  end
+
   test_decode "xml", "'<json>false</json>'::xml", "<json>false</json>"
   test_decode "char", %('c'::"char"), 'c'
   test_decode "bpchar", %('c'::char), "c"

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -85,22 +85,22 @@ module PG
 
           slice = bytes.to_slice[0, 4]
 
-          io.read(slice)
+          io.read_fully(slice)
           slice.hexstring(buffer + 0)
 
           slice = bytes.to_slice[0, 2]
 
-          io.read(slice)
+          io.read_fully(slice)
           slice.hexstring(buffer + 9)
 
-          io.read(slice)
+          io.read_fully(slice)
           slice.hexstring(buffer + 14)
 
-          io.read(slice)
+          io.read_fully(slice)
           slice.hexstring(buffer + 19)
 
           slice = bytes.to_slice
-          io.read(slice)
+          io.read_fully(slice)
           slice.hexstring(buffer + 24)
 
           {36, 36}


### PR DESCRIPTION
Fixes #148 

Just doing `read` could end up not filling the passed slice and so it ended up with garbage bytes.