### PR TITLE
Correctly encode timestamp values to consider microseconds

### DIFF
--- a/spec/pg/encoder_spec.cr
+++ b/spec/pg/encoder_spec.cr
@@ -25,6 +25,7 @@ describe PG::Driver, "encoder" do
 
   test_insert_and_read "timestamp", Time.utc(2015, 2, 3, 17, 15, nanosecond: 13_000_000)
   test_insert_and_read "timestamp", Time.utc(2015, 2, 3, 17, 15, 13, nanosecond: 11_000_000)
+  test_insert_and_read "timestamp", Time.utc(2015, 2, 3, 17, 15, 13, nanosecond: 123_456_000)
 
   test_insert_and_read "bool[]", [true, false, true]
 

--- a/src/pq/param.cr
+++ b/src/pq/param.cr
@@ -1,7 +1,6 @@
 require "../pg/geo"
 
 module PQ
-  ISO_8601 = "%FT%X.%L%z"
   # :nodoc:
   record Param, slice : Slice(UInt8), size : Int32, format : Int16 do
     delegate to_unsafe, to: slice
@@ -21,7 +20,7 @@ module PQ
     end
 
     def self.encode(val : Time)
-      text val.to_s(ISO_8601)
+      text val.to_s("%Y-%m-%d %H:%M:%S.%6N")
     end
 
     def self.encode(val : PG::Geo::Point)


### PR DESCRIPTION
Fixes #140

I was able to reproduce the issue and fix suggested by @aisrael seems to work well.

I could extract the format string to a constant but I didn't know how to name it (maybe like this it's fine).