### PR TITLE
add postgres 12 CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,8 @@ noscram: &noscram
     NOSCRAM: true
 
 jobs:
+  postgresql-12:
+    <<: *testdefault
   postgresql-11:
     <<: *testdefault
   postgresql-10:
@@ -42,6 +44,7 @@ workflows:
   version: 2
   ci:
     jobs:
+      - postgresql-12
       - postgresql-11
       - postgresql-10
       - postgresql-9.6


### PR DESCRIPTION
I intended to also drop 9.4 but it looks like the postgres project supports it until some time between dec 18, 2019 and feb 13, 2020, so might as well keep the builds on until then.