### PR TITLE
Update to crystal-db ~> 0.8.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,4 @@ version: 0.19.0
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.7.0
+    version: ~> 0.8.0


### PR DESCRIPTION
There is a new release of crystal-db.

It would be ideal to release a crystal-pg 0.20.0 IMO
