### PR TITLE
Update to crystal-db ~> 0.9.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,4 @@ version: 0.20.0
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.8.0
+    version: ~> 0.9.0


### PR DESCRIPTION
And keep support for older than Crystal 0.34.0 https://github.com/will/crystal-pg/pull/203#issuecomment-610082732. 

Some tools state that they work with also previous versions of Crystal.

Since we are doing some heavy cleanup for 1.0, soon we can remove them. I usually encourage at least previous + latest support to simplify the migration of apps codebases.

If a v0.21.0 can be released as is it would be great. Let me know if I can give you a hand with something else @will .