### PR TITLE
Allow decoding directly to UUID struct

### DIFF
--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -1,3 +1,4 @@
+require "uuid"
 require "../spec_helper"
 
 describe PG::Decoders do
@@ -32,9 +33,9 @@ describe PG::Decoders do
     Slice(UInt8).new(UInt8[].to_unsafe, 0)
 
   test_decode "uuid", "'7d61d548124c4b38bc05cfbb88cfd1d1'::uuid",
-    "7d61d548-124c-4b38-bc05-cfbb88cfd1d1"
+    UUID.new("7d61d548-124c-4b38-bc05-cfbb88cfd1d1")
   test_decode "uuid", "'7d61d548-124c-4b38-bc05-cfbb88cfd1d1'::uuid",
-    "7d61d548-124c-4b38-bc05-cfbb88cfd1d1"
+    UUID.new("7d61d548-124c-4b38-bc05-cfbb88cfd1d1")
 
   if Helper.db_version_gte(9, 2)
     test_decode "json", %('[1,"a",true]'::json), JSON.parse(%([1,"a",true]))
@@ -65,8 +66,8 @@ describe PG::Decoders do
   end
 
   it "decodes many uuids (#148)" do
-    uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-    ids = PG_DB.query_all("select '#{uuid}'::uuid from generate_series(1,1000)", as: String)
+    uuid = UUID.new("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    ids = PG_DB.query_all("select '#{uuid}'::uuid from generate_series(1,1000)", as: UUID)
     ids.uniq.should eq([uuid])
   end
 

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -56,12 +56,12 @@ module PG
       include Decoder
 
       def_oids [
-        19,       # name (internal type)
-        25,       # text
-        142,      # xml
-        705,      # unknown
-        1042,     # blchar
-        1043,     # varchar
+        19,   # name (internal type)
+        25,   # text
+        142,  # xml
+        705,  # unknown
+        1042, # blchar
+        1043, # varchar
       ]
 
       def decode(io, bytesize, oid)


### PR DESCRIPTION
Crystal: 0.35.1
Postgres: 12.3

One of my apps uses UUIDs for all identifiers, but this requires me to put a `@[DB::Field(converter: UUIDConverter)]` annotation on every single identifier and foreign key in my app models:

```crystal
struct Comment
  include DB::Serializable

  @[DB::Field(converter: UUIDConverter)]
  getter id : UUID
  @[DB::Field(converter: UUIDConverter)]
  getter commentable_id : UUID
  @[DB::Field(converter: UUIDConverter)]
  getter author_id : UUID
end
```

So I thought it'd be really nice if I didn't have to add that annotation every time since Postgres has a UUID data type. And then I saw [this comment](https://github.com/will/crystal-pg/pull/130#issuecomment-359862351) from @RX14:

> However, returning UUIDs as the new `UUID` struct would be something to discuss

So I wanted to at least start that discussion because it would make my application code significantly easier to read.

I also thought it might be faster since we wouldn't have to convert from a raw 128-bit representation off the wire to a chunked hex string and then back again in my app's `UUIDConverter`, so I ran the following benchmark:

<details>
  <summary>Click for benchmark code</summary>

```crystal
require "benchmark"
require "db"
require "uuid"
require "../src/pg"

pg = DB.open("postgres:///")

uuid_count = 1_000_000

memory = 1
time = Benchmark.measure do
  bytes_before_measure = GC.stats.total_bytes
  pg.query_all("select uuid_generate_v4() from generate_series(1, $1)", uuid_count, as: {String})
  memory = (GC.stats.total_bytes - bytes_before_measure).to_i64
end

pp time: time.total, memory_per_uuid: memory // uuid_count
```

For this branch, the `{String}` was changed to `{UUID}`.
</details>

I only measured CPU time to ignore the effects of latency in talking to the DB. On my machine, it took almost 400ms of CPU time to decode 1M rows each containing 1 UUID at about 185 bytes of heap memory for each (acknowledging that most of this is not related to decoding UUIDs):

```
➜  crystal-pg git:(master) ✗ crystal run --release benchmarks/uuid.cr
{time: 0.39878800000000003, memory_per_uuid: 185}
```

Decoding directly to a `UUID`, we use about half of that CPU time and shave off ~39 bytes of heap memory per UUID.

```
➜  crystal-pg git:(decode-uuids) ✗ crystal run --release benchmarks/uuid.cr
{time: 0.174999, memory_per_uuid: 146}
```

Hoping to get people's thoughts on it since this is probably a breaking change for some apps that store UUIDs as the `uuid` type in Postgres since they currently have to treat them as strings.