### PR TITLE
Add support for Postgres INTERVAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Since it uses protocol version 3, older versions probably also work but are not 
 - regtype
 - geo types: point, box, path, lseg, polygon, circle, line
 - array types: int8, int4, int2, float8, float4, bool, text, numeric, timestamptz, date, timestamp
+- interval (2)
 
 1: A note on numeric: In Postgres this type has arbitrary precision. In this
     driver, it is represented as a `PG::Numeric` which retains all precision, but
@@ -141,3 +142,6 @@ Since it uses protocol version 3, older versions probably also work but are not 
     require `pg_ext/big_rational` which adds `#to_big_r`, but requires that you
     have LibGMP installed.
 
+2: A note on interval: A Postgres interval can not be directly mapped to a built
+    in Crystal datatype. Therfore we provide a `PG::Interval` type that can be converted to
+    `Time::Span` and `Time::MonthSpan`.

--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -56,6 +56,12 @@ describe PG::Decoders do
   test_decode "date", "'2015-02-03'::date",
     Time.utc(2015, 2, 3, 0, 0, 0)
 
+
+  # -14706000000 = microseconds in -4 hours, -5 minutes -6 seconds
+  test_decode "interval", "'P-1Y-2M3DT-4H-5M-6S'::interval", PG::Interval.new(-14706000000, 3, -14)
+  test_decode "interval", "'178000000 years'::interval", PG::Interval.new(0, 0, 2_136_000_000)
+  test_decode "interval", "'178000000 years 1 months 5 days 999999 microseconds'::interval", PG::Interval.new(999_999, 5, 2_136_000_001)
+
   it "numeric" do
     x = ->(q : String) do
       PG_DB.query_one "select '#{q}'::numeric", &.read(PG::Numeric)

--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -56,7 +56,6 @@ describe PG::Decoders do
   test_decode "date", "'2015-02-03'::date",
     Time.utc(2015, 2, 3, 0, 0, 0)
 
-
   # -14706000000 = microseconds in -4 hours, -5 minutes -6 seconds
   test_decode "interval", "'P-1Y-2M3DT-4H-5M-6S'::interval", PG::Interval.new(-14706000000, 3, -14)
   test_decode "interval", "'178000000 years'::interval", PG::Interval.new(0, 0, 2_136_000_000)

--- a/spec/pg/interval_spec.cr
+++ b/spec/pg/interval_spec.cr
@@ -1,0 +1,55 @@
+require "../spec_helper"
+
+describe PG::Interval do
+  describe "empty interval" do
+    it "converts to empty Time::Span" do
+      PG::Interval.new.to_span.should eq(Time::Span.new)
+    end
+
+    it "converts to empty Time::MonthSpan" do
+      PG::Interval.new.to_month_span.should eq(Time::MonthSpan.new(0))
+    end
+  end
+
+  describe "overflowing for Time::Span" do
+    it "raises when overflowing" do
+      expect_raises(Exception) do
+        PG::Interval.new(months: -1).to_span
+      end
+      expect_raises(Exception) do
+        PG::Interval.new(months: 1).to_span
+      end
+    end
+
+    it "allows to ignore overflow" do
+      span = PG::Interval.new(microseconds: 123_000_000, months: -1).to_span(true)
+      span.should eq(Time::Span.new(seconds: 123))
+    end
+  end
+
+  describe "to_span" do
+    it "adds days to days contained in microseconds" do
+      # 13.17:23:26.535897
+      interval = PG::Interval.new(microseconds: 149_006_535_897, days: 12)
+      interval.to_span.should eq(Time::Span.new(days: 13, hours: 17, seconds: 1406, nanoseconds: 535_897_000))
+    end
+
+    it "maximum values can be covered by Time::Span" do
+      # MAX = 9_223_372_036_854_775_807
+      interval = PG::Interval.new(microseconds: Int64::MAX, days: Int32::MAX)
+      interval.to_span.should eq(Time::Span.new(days: Int32::MAX, seconds: 9223372036854, nanoseconds: 775_807_000))
+    end
+    it "minimum values can be covered by Time::Span" do
+      # MIN = -9_223_372_036_854_775_808
+      interval = PG::Interval.new(microseconds: Int64::MIN, days: Int32::MIN)
+      interval.to_span.should eq(Time::Span.new(days: Int32::MIN, seconds: -9223372036854, nanoseconds: -775_808_000))
+    end
+  end
+
+  describe "to_month_span" do
+    it "does not add days to months" do
+      interval = PG::Interval.new(months: 123, days: 45)
+      interval.to_month_span.should eq(Time::MonthSpan.new(123))
+    end
+  end
+end

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -432,6 +432,33 @@ module PG
       end
     end
 
+    struct IntervalDecoder
+      include Decoder
+
+      def_oids [
+        1186
+      ]
+      #
+      # An Interval consists of
+      # * time   (8 bytes)
+      # * days   (4 bytes)
+      # * months (4 bytes)
+      #
+      # See: https://github.com/postgres/postgres/blob/a094c8ff53523e88ff9dd28ad467618039e27b58/src/backend/utils/adt/timestamp.c#L1003
+      #
+      def decode(io, bytesize, oid)
+        microseconds = read_i64(io)
+        days = read_i32(io)
+        months = read_i32(io)
+
+        PG::Interval.new(microseconds, days, months)
+      end
+
+      def type
+        PG::Interval
+      end
+    end
+
     struct ByteaDecoder
       include Decoder
 
@@ -496,6 +523,7 @@ module PG
     register_decoder Float32Decoder.new
     register_decoder Float64Decoder.new
     register_decoder TimeDecoder.new
+    register_decoder IntervalDecoder.new
     register_decoder NumericDecoder.new
     register_decoder PointDecoder.new
     register_decoder LineSegmentDecoder.new

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -436,8 +436,9 @@ module PG
       include Decoder
 
       def_oids [
-        1186
+        1186,
       ]
+
       #
       # An Interval consists of
       # * time   (8 bytes)

--- a/src/pg/interval.cr
+++ b/src/pg/interval.cr
@@ -12,7 +12,7 @@ module PG
     #
     # Create a `Time::Span` from this `PG::Interval`
     # If the interval covered in the interval exceeds the range of `Time::Span`
-    # then an exception is raised.
+    #  then an exception is raised.
     #
     def to_span(ignore_overflow = false)
       if !ignore_overflow && months != 0
@@ -35,7 +35,7 @@ module PG
     def to_spans
       {
         to_time_span(false),
-        to_time_month_span
+        to_time_month_span,
       }
     end
   end

--- a/src/pg/interval.cr
+++ b/src/pg/interval.cr
@@ -1,0 +1,42 @@
+module PG
+  #
+  # A representation for INTERVAL data type.
+  # https://www.postgresql.org/docs/current/datatype-datetime.html
+  #
+  struct Interval
+    getter microseconds, days, months
+
+    def initialize(@microseconds : Int64 = 0, @days : Int32 = 0, @months : Int32 = 0)
+    end
+
+    #
+    # Create a `Time::Span` from this `PG::Interval`
+    # If the interval covered in the interval exceeds the range of `Time::Span`
+    # then an exception is raised.
+    #
+    def to_span(ignore_overflow = false)
+      if !ignore_overflow && months != 0
+        message = "This PG::Interval has a month value and can not be covered in a Time::Span." \
+                  "Call #to_span(true) to ignore overflowing parts."
+        raise message
+      end
+
+      div = microseconds.divmod(1_000_000)
+      seconds = div[0]
+      nanoseconds = div[1] * 1_000
+
+      Time::Span.new(days: days, seconds: seconds, nanoseconds: nanoseconds)
+    end
+
+    def to_month_span
+      Time::MonthSpan.new(months)
+    end
+
+    def to_spans
+      {
+        to_time_span(false),
+        to_time_month_span
+      }
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/will/crystal-pg/issues/211

Add support for INTERVAL.

I just started learning Crystal (which so far works well since I'm coming from Ruby) so any feedback is welcome. 

`PG::Interval` allows to convert to `Time::Span`and `Time::MonthSpan` but does not do any roll-over between those spans (does not add days to months).

Some questions:
1) What exception to raise when `PG::Interval` can not be contained in `Time::Span`?
2) Naming of the conversion methods? `to_span` / `to_month_span` is there anything better?
3) Is `Interval#to_spans` useful at all? 

