### PR TITLE
Add config setting auth_methods

### DIFF
--- a/.circleci/pg_hba.conf
+++ b/.circleci/pg_hba.conf
@@ -3,3 +3,4 @@ local   all       postgres                     trust
 host    all       postgres       127.0.0.1/32  trust
 host    all       crystal_md5    127.0.0.1/32  md5
 hostssl all       crystal_ssl    127.0.0.1/32  cert clientcert=1
+host    all       crystal_clear  127.0.0.1/32  password

--- a/spec/pq/authentication_methods_spec.cr
+++ b/spec/pq/authentication_methods_spec.cr
@@ -7,9 +7,10 @@ require "../spec_helper"
 # Because of this, most of these specs are disabled by default. To enable them
 # place an empty file called .run_auth_specs in /spec
 
+CURRENT_DATABASE = PG_DB.query_one("select current_database()", &.read)
+
 private def test_role(role, pass)
-  db = PG_DB.query_one("select current_database()", &.read)
-  url = "postgres://#{role}:#{pass}@127.0.0.1/#{db}"
+  url = "postgres://#{role}:#{pass}@127.0.0.1/#{CURRENT_DATABASE}"
   DB.open(url) do |db|
     db.query_one("select 1", &.read).should eq(1)
   end
@@ -53,6 +54,19 @@ if File.exists?(File.join(File.dirname(__FILE__), "../.run_auth_specs"))
 
       PG_DB.exec("drop role if exists crystal_scram")
     end
+
+    it "fails if auth_method is disabled" do
+      PG_DB.exec("drop role if exists crystal_scram")
+      PG_DB.exec("set password_encryption='scram-sha-256'")
+      PG_DB.exec("create role crystal_scram login encrypted password 'pass'")
+
+      exc = expect_raises(DB::ConnectionRefused) {
+        DB.open("postgres://crystal_scram:pass@127.0.0.1?auth_methods=cleartext,md5")
+      }
+      exc.cause.try(&.message).to_s.should contain "server asked for disabled authentication method: scram-sha-256"
+
+      PG_DB.exec("drop role if exists crystal_md5")
+    end
   end if Helper.db_version_gte(10)
 
   describe PQ::Connection, "md5 auth" do
@@ -79,6 +93,19 @@ if File.exists?(File.join(File.dirname(__FILE__), "../.run_auth_specs"))
 
       PG_DB.exec("drop role if exists crystal_md5")
     end
+
+    it "fails if auth_method is disabled" do
+      PG_DB.exec("drop role if exists crystal_md5")
+      PG_DB.exec("set password_encryption='md5'") if Helper.db_version_gte(10)
+      PG_DB.exec("create role crystal_md5 login encrypted password 'pass'")
+
+      exc = expect_raises(DB::ConnectionRefused) {
+        DB.open("postgres://crystal_md5:pass@127.0.0.1?auth_methods=cleartext,scram-sha-256")
+      }
+      exc.cause.try(&.message).to_s.should contain "server asked for disabled authentication method: md5"
+
+      PG_DB.exec("drop role if exists crystal_md5")
+    end
   end
 
   describe PQ::Connection, "ssl clientcert auth" do
@@ -92,6 +119,36 @@ if File.exists?(File.join(File.dirname(__FILE__), "../.run_auth_specs"))
         db.query_one("select current_user", &.read).should eq("crystal_ssl")
       end
       PG_DB.exec("drop role if exists crystal_ssl")
+    end
+  end
+
+  describe PQ::Connection, "cleartext auth" do
+    it "fails by default" do
+      PG_DB.exec("drop role if exists crystal_clear")
+      PG_DB.exec("create role crystal_clear login encrypted password 'pass'")
+
+      exc = expect_raises(DB::ConnectionRefused) {
+        DB.open("postgres://crystal_clear:pass@127.0.0.1")
+      }
+      exc.cause.try(&.message).to_s.should contain "server asked for disabled authentication method: cleartext"
+
+      exc = expect_raises(DB::ConnectionRefused) {
+        DB.open("postgres://crystal_clear:pass@127.0.0.1?auth_methods=md5,scram-sha-256")
+      }
+      exc.cause.try(&.message).to_s.should contain "server asked for disabled authentication method: cleartext"
+
+      PG_DB.exec("drop role if exists crystal_clear")
+    end
+
+    it "works when auth_method is enabled" do
+      PG_DB.exec("drop role if exists crystal_clear")
+      PG_DB.exec("create role crystal_clear login encrypted password 'pass'")
+
+      DB.open("postgres://crystal_clear:pass@127.0.0.1/#{CURRENT_DATABASE}?auth_methods=cleartext") { }
+
+      DB.open("postgres://crystal_clear:pass@127.0.0.1/#{CURRENT_DATABASE}?auth_methods=cleartext,md5,scram-sha-256") { }
+
+      PG_DB.exec("drop role if exists crystal_clear")
     end
   end
 else

--- a/spec/pq/conninfo_spec.cr
+++ b/spec/pq/conninfo_spec.cr
@@ -83,4 +83,25 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
     ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@[::1]:5555/db")
     ci.host.should eq("::1")
   end
+
+  it "auth_methods" do
+    ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@localhost/foo")
+    ci.auth_methods.should eq ["scram-sha-256", "md5"]
+
+    ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@localhost/foo?auth_methods=md5")
+    ci.auth_methods.should eq ["md5"]
+
+    ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@localhost/foo?auth_methods=")
+    ci.auth_methods.should eq [] of String
+
+    ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@localhost/foo?auth_methods=cleartext,md5,scram-sha-256")
+    ci.auth_methods.should eq ["cleartext", "md5", "scram-sha-256"]
+
+    expect_raises Exception do
+      PQ::ConnInfo.from_conninfo_string("postgres://user:pass@localhost/foo?auth_methods=unsupported")
+    end
+    expect_raises Exception do
+      PQ::ConnInfo.from_conninfo_string("postgres://user:pass@localhost/foo?auth_methods=md5,unsupported")
+    end
+  end
 end

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -265,6 +265,7 @@ module PQ
 
         handle_auth_cleartext auth_frame.body
       when Frame::Authentication::Type::SASL
+        # check_auth_method! is called in sasl handler
         handle_auth_sasl auth_frame.body
       when Frame::Authentication::Type::MD5Password
         check_auth_method!("md5")

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -261,14 +261,26 @@ module PQ
       when Frame::Authentication::Type::OK
         # no op
       when Frame::Authentication::Type::CleartextPassword
-        raise "Cleartext auth is not supported"
+        check_auth_method!("cleartext")
+
+        handle_auth_cleartext auth_frame.body
       when Frame::Authentication::Type::SASL
         handle_auth_sasl auth_frame.body
       when Frame::Authentication::Type::MD5Password
+        check_auth_method!("md5")
+
         handle_auth_md5 auth_frame.body
       else
         raise ConnectionError.new(
           "unsupported authentication method: #{auth_frame.type}"
+        )
+      end
+    end
+
+    private def check_auth_method!(method)
+      unless @conninfo.auth_methods.includes?(method)
+        raise ConnectionError.new(
+          "server asked for disabled authentication method: #{method}"
         )
       end
     end
@@ -315,6 +327,14 @@ module PQ
     private def handle_auth_sasl(mechanism_list)
       # it is possible in the future for postgres to send something other than
       # SCRAM-SHA-265, but for now ignore the mechanism_list
+      mechanism_list = String.new(mechanism_list).split(Char::ZERO)
+      unless mechanism_list.includes?("SCRAM-SHA-256")
+        raise ConnectionError.new(
+          "unsupported authentication method: #{mechanism_list.join(", ")}"
+        )
+      end
+
+      check_auth_method!("scram-sha-256")
 
       ctx = SamlContext.new(@conninfo.password || "")
 
@@ -353,6 +373,11 @@ module PQ
       end
 
       send_password_message "md5#{pass}"
+      expect_frame Frame::Authentication
+    end
+
+    private def handle_auth_cleartext(body)
+      send_password_message @conninfo.password
       expect_frame Frame::Authentication
     end
 

--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -5,6 +5,8 @@ module PQ
   struct ConnInfo
     SOCKET_SEARCH = %w(/run/postgresql/.s.PGSQL.5432 /tmp/.s.PGSQL.5432 /var/run/postgresql/.s.PGSQL.5432)
 
+    SUPPORTED_AUTH_METHODS = ["cleartext", "md5", "scram-sha-256"]
+
     # The host. If starts with a / it is assumed to be a local Unix socket.
     getter host : String
 
@@ -31,6 +33,8 @@ module PQ
 
     # The sslrootcert. Optional.
     getter sslrootcert : String?
+
+    getter auth_methods : Array(String) = ["scram-sha-256", "md5"] of String
 
     # Create a new ConnInfo from all parts
     def initialize(host : String? = nil, database : String? = nil, user : String? = nil, @password : String? = nil, port : Int | String? = 5432, sslmode : String | Symbol? = nil)
@@ -94,6 +98,14 @@ module PQ
         @sslkey = value
       when "sslrootcert"
         @sslrootcert = value
+      when "auth_methods"
+        methods = value.split(",").compact_map(&.underscore.presence).uniq
+        methods.each do |method|
+          unless method.in?(SUPPORTED_AUTH_METHODS)
+            raise "invalid auth_method #{method}"
+          end
+        end
+        @auth_methods = methods
       else
         # ignore
       end


### PR DESCRIPTION
This adds a `auth_methods` config setting which allows to configure which auth methods the client should accept.

The settings value is a list of comma separated values. The default is `scram-sha-256,md5`. `cleartext` needs to be explicitly enabled.

Is there any place where documentation can be added?

I didn't do anything about `OK` authentication frame. A safe default should also fail if the server just passes you through without a credential check.
But this is more complicated because it is fine with SSL client certificate for example.
So it needs more work. For now I'm just posting this patch.

Superseeds #218
cf crystal-lang/crystal-db#141