### PR TITLE
Read Slice(UInt8) as String if given as type

### DIFF
--- a/spec/pg/driver_spec.cr
+++ b/spec/pg/driver_spec.cr
@@ -95,6 +95,19 @@ describe PG::Driver do
     end
   end
 
+  it "treats Slice(UInt8) as String" do
+    with_db do |db|
+      db.exec "create extension if not exists citext with schema public"
+      db.exec "drop table if exists users"
+      db.exec "create table users (email citext)"
+      db.exec "insert into users values ($1)", "foo@example.com"
+
+      db.query "select email from users limit 1" do |rs|
+        assert_single_read rs, String, "foo@example.com"
+      end
+    end
+  end
+
   describe "transactions" do
     it "can read inside transaction and rollback after" do
       with_db do |db|

--- a/spec/pg/driver_spec.cr
+++ b/spec/pg/driver_spec.cr
@@ -105,6 +105,10 @@ describe PG::Driver do
       db.query "select email from users limit 1" do |rs|
         assert_single_read rs, String, "foo@example.com"
       end
+
+      db.query "select email from users limit 1" do |rs|
+        assert_single_read rs, String?, "foo@example.com"
+      end
     end
   end
 

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -92,6 +92,17 @@ class PG::ResultSet < ::DB::ResultSet
     end
   end
 
+  def read(t : String.class) : String
+    value = read
+    if value.is_a?(String)
+      value
+    elsif value.is_a?(Slice(UInt8))
+      String.new(value)
+    else
+      raise "#{self.class}#read returned a #{value.class}. A String was expected."
+    end
+  end
+
   private def read_array(t : T.class) : T forall T
     col_bytesize = conn.read_i32
     if col_bytesize == -1

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -93,13 +93,24 @@ class PG::ResultSet < ::DB::ResultSet
   end
 
   def read(t : String.class) : String
-    value = read
-    if value.is_a?(String)
-      value
-    elsif value.is_a?(Slice(UInt8))
+    value = read(String | Slice(UInt8))
+
+    case value
+    when Slice(UInt8)
       String.new(value)
     else
-      raise "#{self.class}#read returned a #{value.class}. A String was expected."
+      value
+    end
+  end
+
+  def read(t : String?.class) : String?
+    value = read(String | Slice(UInt8) | Nil)
+
+    case value
+    when Slice(UInt8)
+      String.new(value)
+    else
+      value
     end
   end
 


### PR DESCRIPTION
Fixes #43

In order to support the citext extension in Avram, we need to be able to treat the column as a String. Two solutions were laid out in the connected issue:

- A: Calling `rs.read(String)` on a string-like column (citext, enum or similar), it should return a String.
- B: Calling `rs.read` on a string-like column, it should probably also return a String.

B was considered the more "complete solution" but also the more complicated. Since it's been 4 years since the issue was opened and over a year since the potential solutions were laid out, I went with the more immediate option A. If the read type is `Slice(UInt8)`, which is the type of a citext column, and `#read` was called with a type of `String`, then convert it to String. This helps with citext interop and I'm sure it helps with other column types as well.
