### PR TITLE
Update for Crystal 0.36 compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,4 +6,4 @@ dependencies:
     github: crystal-lang/crystal-db
     version: ~> 0.10.0
 
-crystal: 0.35.0
+crystal: ">= 0.35.0, < 2.0.0"

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -34,6 +34,6 @@ end
 def test_decode(name, query, expected, file = __FILE__, line = __LINE__)
   it name, file, line do
     value = PG_DB.query_one "select #{query}", &.read
-    value.should eq(expected), file, line
+    value.should eq(expected), file: file, line: line
   end
 end


### PR DESCRIPTION
This PR makes the spec build on Crystal 0.36 without warnings.
The changes are backward compatibly with 0.35.

Another optional change is to declare this shard compatible with 1.0.0-x which should be almost 0.36. Is not mandatory and --ignore-crystal-version can be used otherwise.