### PR TITLE
Reuse IO::Sized instances in ResultSet

### DIFF
--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -15,6 +15,7 @@ class PG::ResultSet < ::DB::ResultSet
     @column_index = -1 # The current column
     @end = false       # Did we read all the rows?
     @rows_affected = 0_i64
+    @sized_io = IO::Sized.new(conn.soc, 1)
   end
 
   protected def conn
@@ -138,15 +139,15 @@ class PG::ResultSet < ::DB::ResultSet
   end
 
   private def safe_read(col_bytesize)
-    sized_io = IO::Sized.new(conn.soc, col_bytesize)
+    @sized_io.read_remaining = col_bytesize.to_u64
 
     begin
-      yield sized_io
+      yield @sized_io
     ensure
       # An exception might happen while decoding the value:
       # 1. Make sure to skip the column bytes
       # 2. Make sure to increment the column index
-      conn.soc.skip(sized_io.read_remaining) if sized_io.read_remaining > 0
+      conn.soc.skip(@sized_io.read_remaining) if @sized_io.read_remaining > 0
       @column_index += 1
     end
   end

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -1,3 +1,12 @@
+# Remove this monkeypatch when we want to drop support for Crystal < 1.0
+# Crystal versions above 1.0 should have this already, added in this pr:
+# https://github.com/crystal-lang/crystal/pull/10520
+{% unless IO::Sized.has_method?(:read_remaining=) %}
+  class IO::Sized
+    setter read_remaining
+  end
+{% end %}
+
 class PG::ResultSet < ::DB::ResultSet
   getter rows_affected
 


### PR DESCRIPTION
_TL;DR: Reduced CPU consumption by about 73%, but still needs some polish_

I've been benchmarking Crystal vs Rust/Go for some reasonably realistic workloads. A while back I compared [communicating with Redis](https://dev.to/jgaskins/performance-comparison-rust-vs-crystal-with-redis-1a17) (because it's simple) between Rust and Crystal — Crystal beat Rust by a factor of 2-3x.

This week I ran a similar set of benchmarks for Postgres, using [Diesel](https://diesel.rs) for Rust and [Interro](https://github.com/jgaskins/interro) for Crystal, with varying horse-sized-duck and duck-sized-horse queries, and Rust beat Crystal by almost the same amount, so I started looking and found that [`PG::ResultSet#read` calls `safe_read`](https://github.com/will/crystal-pg/blob/cafe039cfd6340a271e81603943bb1975f5a91f5/src/pg/result_set.cr#L76-L78), which [instantiates an `IO::Sized`](https://github.com/will/crystal-pg/blob/cafe039cfd6340a271e81603943bb1975f5a91f5/src/pg/result_set.cr#L131-L132). This appears to be called for every column of every row, so if a table is super wide (whether it just accrued cruft) or the result set has a crap-ton of rows, it's going to create a _lot_ of these `IO::Sized` instances that only live long enough to decode a single value from a result set. Because `IO::Sized` is allocated on the heap, this results in a _lot_ of garbage.

This PR creates a single instance of `IO::Sized` to be reused and moves the goal post every time we need to read a value. Here is the result:

<details>
<summary>Click here for benchmark code (not the same benchmark as used for Interro and Diesel, mentioned above)</summary>

```crystal
require "benchmark"
require "db"
require "../src/pg"

struct Model
  include DB::Serializable
  getter float : Float64
  getter int : Int32
  getter string : String
  getter uuid : UUID
  getter nullable : String?
end
db = DB.open("postgres:///")

query = <<-SQL
  SELECT
    random() AS float,
    (random() * 1000000000)::int AS int,
    random()::text AS string,
    uuid_generate_v4() AS uuid,
    NULL AS nullable
  FROM generate_series(1, 100000)
SQL
args = [] of String
model = nil
bm = Benchmark.measure do
  db.query_each query do |rs|
    model = rs.read(Model)
  end
end

pp model # Ensure LLVM doesn't optimize out the `rs.read` calls

pp wall_clock: bm.real, cpu: bm.total
```

</details>

| | Wall clock | CPU |
|-|-|-|
| Before | 0.193830283 | 0.135133 |
| After | 0.135133 | 0.036025 |

This uses _73% less_ CPU time than the currently released version, which I found kinda mind-boggling. In my benchmark of Interro (Crystal) vs Diesel (Rust), with this patch Interro is now using as little CPU time as Diesel, at 7.04 vs 7.12, respectively:

```
bin/interro_bench            4.38s user 2.66s system 31% cpu 22.073 total
target/release/diesel_bench  6.17s user 0.95s system 42% cpu 16.630 total
```

I don't know why the wall-clock times are so different, but it may have to do with similarly wild difference in system CPU time. On my M1 Mac, the system CPU times are nearly identical with this patch so I'm not entirely sure what's up there:

```
bin/interro_bench            3.03s user 0.47s system 44% cpu 7.940 total
target/release/diesel_bench  4.05s user 0.43s system 57% cpu 7.753 total
```

__NOTE:__ This is a draft PR purely because I'm not thrilled with the idea of extending a stdlib class to make it externally mutable. It feels brittle because it exposes an implementation details that was previously encapsulated. I only used it because it took absolutely minimal effort. 🙂 I figure a final version of this could either be a simplified implementation of `IO::Sized` (the existing one [isn't huge](https://github.com/crystal-lang/crystal/blob/c3a3c1823/src/io/sized.cr#L11-L85) and includes methods we probably don't need here), but I wanted to get your input on that first.