### PR TITLE
Json columns are read as JSON::PullParser instead of JSON::Any

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v?.?.?     upcoming
 =====================
+* Decode json columns as JSON::PullParser instead of JSON::Any (thanks @matthewmcgarvey)
 
 v0.23.2    2020-03-27
 =====================

--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -38,11 +38,11 @@ describe PG::Decoders do
     UUID.new("7d61d548-124c-4b38-bc05-cfbb88cfd1d1")
 
   if Helper.db_version_gte(9, 2)
-    test_decode "json", %('[1,"a",true]'::json), JSON.parse(%([1,"a",true]))
-    test_decode "json", %('{"a":1}'::json), JSON.parse(%({"a":1}))
+    test_decode "json", %('[1,"a",true]'::json), JSON::PullParser.new(%([1,"a",true]))
+    test_decode "json", %('{"a":1}'::json), JSON::PullParser.new(%({"a":1}))
   end
   if Helper.db_version_gte(9, 4)
-    test_decode "jsonb", "'[1,2,3]'::jsonb", JSON.parse("[1,2,3]")
+    test_decode "jsonb", "'[1,2,3]'::jsonb", JSON::PullParser.new("[1,2,3]")
   end
 
   test_decode "timestamptz", "'2015-02-03 16:15:13-01'::timestamptz",

--- a/spec/pg/driver_spec.cr
+++ b/spec/pg/driver_spec.cr
@@ -112,6 +112,18 @@ describe PG::Driver do
     end
   end
 
+  it "converts json result into JSON::Any if requested" do
+    with_db do |db|
+      db.exec "drop table if exists users"
+      db.exec "create table users (properties jsonb)"
+      db.exec "insert into users values ($1)", "{\"hello\": \"world\"}"
+
+      db.query "select properties from users limit 1" do |rs|
+        assert_single_read rs, JSON::Any, JSON.parse("{\"hello\": \"world\"}")
+      end
+    end
+  end
+
   describe "transactions" do
     it "can read inside transaction and rollback after" do
       with_db do |db|

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -37,3 +37,11 @@ def test_decode(name, query, expected, file = __FILE__, line = __LINE__)
     value.should eq(expected), file: file, line: line
   end
 end
+
+def test_decode(name, query, expected : JSON::PullParser, file = __FILE__, line = __LINE__)
+  it name, file, line do
+    value = PG_DB.query_one "select #{query}", &.read
+    json_value = value.is_a?(JSON::PullParser) ? JSON::Any.new(value) : value
+    json_value.should eq(JSON::Any.new(expected)), file: file, line: line
+  end
+end

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -382,11 +382,11 @@ module PG
           io.read_fully(Slice.new(buffer, bytesize))
           {bytesize, 0}
         end
-        JSON.parse(string)
+        JSON::PullParser.new(string)
       end
 
       def type
-        JSON::Any
+        JSON::PullParser
       end
     end
 

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -124,6 +124,16 @@ class PG::ResultSet < ::DB::ResultSet
     end
   end
 
+  def read(t : JSON::Any.class) : JSON::Any
+    value = read(JSON::PullParser)
+    JSON::Any.new(value)
+  end
+
+  def read(t : JSON::Any?.class) : JSON::Any?
+    value = read(JSON::PullParser?)
+    JSON::Any.new(value) if value
+  end
+
   private def read_array(t : T.class) : T forall T
     col_bytesize = conn.read_i32
     if col_bytesize == -1


### PR DESCRIPTION
Fixes #125 

Currently, if you have a json column and read it with this library, it is automatically turned into a `JSON::Any`. It makes sense when you don't care about the structure, but there's two problems with doing that:
1. `JSON::Any` is immutable so that values cannot be changed and then saved back to the database
2. You cannot convert a `JSON::Any` into a `JSON::Serializable`

This PR changes the default deserialization of json columns from `JSON::Any` to `JSON::PullParser`. The benefit we get from this is that it can easily be converted into a `JSON::Any` or a `JSON::Serializable`. It is still not mutable but it's easier to get to a mutable setting:

```crystal
properties = result_set.read(JSON::PullParser)
mutable_properties = Hash(String, String).new(properties)
```

I added a method specifically for still supporting calling `result_set.read(JSON::Any)` with hopes that will cause the least amount of breakage, because this is definitely a breaking change.