### PR TITLE
Add scram channel binding (scram-sha-265-plus)

### DIFF
--- a/spec/pq/conninfo_spec.cr
+++ b/spec/pq/conninfo_spec.cr
@@ -86,7 +86,7 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
 
   it "auth_methods" do
     ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@localhost/foo")
-    ci.auth_methods.should eq ["scram-sha-256", "md5"]
+    ci.auth_methods.should eq ["scram-sha-256-plus", "scram-sha-256", "md5"]
 
     ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@localhost/foo?auth_methods=md5")
     ci.auth_methods.should eq ["md5"]

--- a/src/ext/openssl.cr
+++ b/src/ext/openssl.cr
@@ -1,0 +1,84 @@
+require "openssl"
+
+class OpenSSL::X509::Certificate
+  def scram_signature
+    # The TLS server's certificate bytes need to be hashed with SHA-256 if
+    # its signature algorithm is MD5 or SHA-1 as per RFC 5929
+    # (https://tools.ietf.org/html/rfc5929#section-4.1).  If something else
+    # is used, the same hash as the signature algorithm is used.
+    algo_type = signature_algorithm
+    algo_type = "SHA256" if algo_type == "MD5" || algo_type == "SHA1"
+    digest algo_type
+  end
+end
+
+# Backport of https://github.com/crystal-lang/crystal/pull/8005
+# for Crystal versions < 1.1.0. Can be removed once crystal-pg no longer
+# supports those versions of Crystal
+{% if compare_versions(Crystal::VERSION, "1.1.0") < 0 %}
+  class OpenSSL::SSL::Socket::Client
+    # Returns the `OpenSSL::X509::Certificate` the peer presented.
+    def peer_certificate : OpenSSL::X509::Certificate
+      super.not_nil!
+    end
+  end
+
+  class OpenSSL::SSL::Socket
+    # Returns the `OpenSSL::X509::Certificate` the peer presented, if a
+    # connection was esablished.
+    #
+    # NOTE: Due to the protocol definition, a TLS/SSL server will always send a
+    # certificate, if present. A client will only send a certificate when
+    # explicitly requested to do so by the server (see `SSL_CTX_set_verify(3)`). If
+    # an anonymous cipher is used, no certificates are sent. That a certificate
+    # is returned does not indicate information about the verification state.
+    def peer_certificate : OpenSSL::X509::Certificate?
+      cert = LibSSL.ssl_get_peer_certificate(@ssl)
+      OpenSSL::X509::Certificate.new cert if cert
+    end
+  end
+
+  class OpenSSL::X509::Certificate
+    # Returns the name of the signature algorithm.
+    def signature_algorithm : String
+      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+        sigid = LibCrypto.x509_get_signature_nid(@cert)
+        result = LibCrypto.obj_find_sigid_algs(sigid, out algo_nid, nil)
+        raise "Could not determine certificate signature algorithm" if result == 0
+
+        sn = LibCrypto.obj_nid2sn(algo_nid)
+        raise "Unknown algo NID #{algo_nid.inspect}" if sn.null?
+        String.new sn
+      {% else %}
+        raise "Missing OpenSSL function for certificate signature algorithm (requires OpenSSL 1.0.2)"
+      {% end %}
+    end
+
+    # Returns the digest using *algorithm_name*
+    # ```
+    # cert.digest("SHA1").hexstring   # => "6f608752059150c9b3450a9fe0a0716b4f3fa0ca"
+    # cert.digest("SHA256").hexstring # => "51d80c865cc717f181cd949f0b23b5e1e82c93e01db53f0836443ec908b83748"
+    # ```
+    def digest(algorithm_name : String) : Slice(UInt8)
+      algo_type = LibCrypto.evp_get_digestbyname algorithm_name
+      raise ArgumentError.new "could not find digest for '#{algorithm_name}'" if Pointer(Void).null == algo_type
+      hash = Slice(UInt8).new(64) # EVP_MAX_MD_SIZE for SHA512
+      result = LibCrypto.x509_digest(@cert, algo_type, hash, out size)
+      raise "could not generate certificate hash" unless result == 1
+
+      hash[0, size]
+    end
+  end
+
+  lib LibSSL
+    fun ssl_get_peer_certificate = SSL_get_peer_certificate(handle : SSL) : LibCrypto::X509
+  end
+
+  lib LibCrypto
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+      fun obj_find_sigid_algs = OBJ_find_sigid_algs(sigid : Int32, pdig_nid : Int32*, ppkey_nid : Int32*) : Int32
+      fun x509_get_signature_nid = X509_get_signature_nid(x509 : X509) : Int32
+    {% end %}
+    fun x509_digest = X509_digest(x509 : X509, evp_md : EVP_MD, hash : UInt8*, len : Int32*) : Int32
+  end
+{% end %}

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -5,6 +5,8 @@ require "socket/tcp_socket"
 require "socket/unix_socket"
 require "openssl"
 require "openssl/hmac"
+require "./notice"
+require "../ext/openssl"
 
 module PQ
   record Notification, pid : Int32, channel : String, payload : String
@@ -287,13 +289,27 @@ module PQ
     end
 
     struct SamlContext
-      property client_first_msg : String
-      property client_first_msg_size : Int32
+      SCRAM_NAME      = "SCRAM-SHA-256"
+      SCRAM_PLUS_NAME = "SCRAM-SHA-256-PLUS"
 
-      def initialize(@password : String)
+      getter name : String
+      getter client_first_msg : String
+      getter signature : Slice(UInt8)?
+
+      def initialize(@password : String, @cbind : Bool, soc)
         @client_nonce = Random::Secure.urlsafe_base64(18)
-        @client_first_msg = "n,,n=,r=#{@client_nonce}"
-        @client_first_msg_size = @client_first_msg.bytesize
+
+        if @cbind
+          @name = SCRAM_PLUS_NAME
+          cbind_flag = "p=tls-server-end-point"
+          cert = soc.as(OpenSSL::SSL::Socket::Client).peer_certificate
+          @signature = cert.scram_signature
+        else
+          @name = SCRAM_NAME
+          cbind_flag = "n"
+        end
+
+        @client_first_msg = "#{cbind_flag},,n=,r=#{@client_nonce}"
       end
 
       def generate_client_final_message(body)
@@ -304,7 +320,14 @@ module PQ
         i = params.find { |p| p[0] == 'i' }.not_nil![2..-1].to_i
         raise ConnectionError.new("SASL: scram server nonce does not start with client nonce") unless r.starts_with?(@client_nonce)
 
-        client_final_msg_without_proof = "c=biws,r=#{r}"
+        if @signature
+          # cd10b...Cws == base64 of "p=tls-server-end-point,,"
+          b64sig = Base64.strict_encode @signature.not_nil!
+          client_final_msg_without_proof = "c=cD10bHMtc2VydmVyLWVuZC1wb2ludCws#{b64sig},r=#{r}"
+        else
+          # biws == base64 of "n,,"
+          client_final_msg_without_proof = "c=biws,r=#{r}"
+        end
         salted_pass = OpenSSL::PKCS5.pbkdf2_hmac(@password, Base64.decode(s), i, algorithm: OpenSSL::Algorithm::SHA256, key_size: 32)
         server_key = OpenSSL::HMAC.digest(:sha256, salted_pass, "Server Key")
         client_key = OpenSSL::HMAC.digest(:sha256, salted_pass, "Client Key")
@@ -326,25 +349,25 @@ module PQ
     end
 
     private def handle_auth_sasl(mechanism_list)
-      # it is possible in the future for postgres to send something other than
-      # SCRAM-SHA-265, but for now ignore the mechanism_list
-      mechanism_list = String.new(mechanism_list).split(Char::ZERO)
-      unless mechanism_list.includes?("SCRAM-SHA-256")
-        raise ConnectionError.new(
-          "unsupported authentication method: #{mechanism_list.join(", ")}"
-        )
-      end
+      mechs = String.new(mechanism_list).split(Char::ZERO)
+      cbind = if mechs.includes?(SamlContext::SCRAM_PLUS_NAME)
+                check_auth_method!("scram-sha-256-plus")
+                true
+              elsif mechs.includes?(SamlContext::SCRAM_NAME)
+                check_auth_method!("scram-sha-256")
+                false
+              else
+                raise ConnectionError.new("no known sasl mechanism in list: #{mechs.join(", ")}")
+              end
 
-      check_auth_method!("scram-sha-256")
-
-      ctx = SamlContext.new(@conninfo.password || "")
+      ctx = SamlContext.new(@conninfo.password || "", cbind, soc)
 
       # send client-first-message
       write_chr 'p' # SASLInitialResponse
-      write_i32 4 + 13 + 1 + 4 + ctx.client_first_msg_size
-      soc << "SCRAM-SHA-256"
+      write_i32 4 + ctx.name.bytesize + 1 + 4 + ctx.client_first_msg.bytesize
+      soc << ctx.name
       write_null
-      write_i32 ctx.client_first_msg_size
+      write_i32 ctx.client_first_msg.bytesize
       soc << ctx.client_first_msg
       soc.flush
 

--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -5,7 +5,7 @@ module PQ
   struct ConnInfo
     SOCKET_SEARCH = %w(/run/postgresql/.s.PGSQL.5432 /tmp/.s.PGSQL.5432 /var/run/postgresql/.s.PGSQL.5432)
 
-    SUPPORTED_AUTH_METHODS = ["cleartext", "md5", "scram-sha-256"]
+    SUPPORTED_AUTH_METHODS = %w[cleartext md5 scram-sha-256 scram-sha-256-plus]
 
     # The host. If starts with a / it is assumed to be a local Unix socket.
     getter host : String
@@ -34,7 +34,7 @@ module PQ
     # The sslrootcert. Optional.
     getter sslrootcert : String?
 
-    getter auth_methods : Array(String) = ["scram-sha-256", "md5"] of String
+    getter auth_methods : Array(String) = %w[scram-sha-256-plus scram-sha-256 md5]
 
     # Create a new ConnInfo from all parts
     def initialize(host : String? = nil, database : String? = nil, user : String? = nil, @password : String? = nil, port : Int | String? = 5432, sslmode : String | Symbol? = nil)

--- a/src/pq/frame.cr
+++ b/src/pq/frame.cr
@@ -1,3 +1,5 @@
+require "./field"
+
 module PQ
   # :nodoc:
   abstract struct Frame

--- a/src/pq/notice.cr
+++ b/src/pq/notice.cr
@@ -1,3 +1,5 @@
+require "./frame"
+
 module PQ
   # http://www.postgresql.org/docs/current/static/protocol-error-fields.html
   struct Notice


### PR DESCRIPTION
This will be preferred when the Postgres server offers it, as it is
strictly better than scram without channel binding. This was a new
feature in Postgres 11. Postgres 10 supports scram, but not channel
binding.

It requires a few extra openssl functions linked, which did not become a
part of Crystal until version 1.1.0, so I've backported that patch for
earlier versions of Crystal.