### PR TITLE
Add pg14, remove pg9.5 from CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ noscram: &noscram
     NOSCRAM: true
 
 jobs:
+  postgresql-14:
+    <<: *testdefault
   postgresql-13:
     <<: *testdefault
   postgresql-12:
@@ -32,9 +34,6 @@ jobs:
   postgresql-10:
     <<: *testdefault
   postgresql-9.6:
-    <<: *testdefault
-    <<: *noscram
-  postgresql-9.5:
     <<: *testdefault
     <<: *noscram
   check_format:
@@ -48,11 +47,11 @@ workflows:
   version: 2
   ci:
     jobs:
+      - postgresql-14
       - postgresql-13
       - postgresql-12
       - postgresql-11
       - postgresql-10
       - postgresql-9.6
-      - postgresql-9.5
       - check_format
 

--- a/.circleci/pg_hba.conf
+++ b/.circleci/pg_hba.conf
@@ -2,5 +2,5 @@
 local   all       postgres                     trust
 host    all       postgres       127.0.0.1/32  trust
 host    all       crystal_md5    127.0.0.1/32  md5
-hostssl all       crystal_ssl    127.0.0.1/32  cert clientcert=1
+hostssl all       crystal_ssl    127.0.0.1/32  cert
 host    all       crystal_clear  127.0.0.1/32  password


### PR DESCRIPTION
9.5 fell out of support on February 11, 2021
https://www.postgresql.org/support/versioning/