### PR TITLE
registering UUID Arrays

### DIFF
--- a/spec/pg/decoders/array_decoder_spec.cr
+++ b/spec/pg/decoders/array_decoder_spec.cr
@@ -105,6 +105,7 @@ describe PG::Decoders do
   test_decode "date array", "array[to_date('20170103', 'YYYYMMDD')]", [Time.utc(2017, 1, 3)]
   test_decode "numeric array", "array[1::numeric]", [PG::Numeric.new(ndigits: 1, weight: 0, sign: PG::Numeric::Sign::Pos.value, dscale: 0, digits: [1] of Int16)]
   test_decode "time array", "array[to_date('20170103', 'YYYYMMDD')::timestamp]", [Time.utc(2017, 1, 3)]
+  test_decode "uuid array", "array['f0c66172-f617-4bb4-95f4-5677a093cedb']::uuid[]", [UUID.new("f0c66172-f617-4bb4-95f4-5677a093cedb")]
 
   it "errors when expecting array returns null" do
     expect_raises(PG::RuntimeError, "unexpected NULL, expecting to read Array(String)") do

--- a/src/pg/decoders/array_decoder.cr
+++ b/src/pg/decoders/array_decoder.cr
@@ -173,4 +173,5 @@ module PG
   array_type String, 1009
   array_type Numeric, 1231
   array_type Time, [1115, 1182]
+  array_type UUID, 2951
 end


### PR DESCRIPTION
This fixes a bug when getting the value of a `Array(UUID)` from postgres giving you `Bytes` instead of `Array(PG::UUIDArray)`.

It seems when I added https://github.com/will/crystal-pg/pull/225 I forgot this extra bit 😬  oops!