### PR TITLE
Add defense-in-depth for CVE-2021-23222

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v?.?.?     upcoming
 =====================
+* Add defense-in-depth for CVE-2021-23222
 * Add scram-sha-256-plus "scram with channel binding". If your version of
   postgres does support this, you should provide only this as your
   `auth_methods` in order to exclude the non-plus/non-channel-binding version


### PR DESCRIPTION
CVE-2021-23222 (announced today 2021-11-11) doesn't directly affect this driver as it does
libpq-based drivers, since this driver only reads the single byte when
checking for TLS support on the server instead of eagerly reading as
much data as possible.

However, should this attack be attempted on this driver, it shows up as
the TLS handshake failing. Instead, check for this attack and raise an
error with the evidence, so users can know that there is a
man-in-the-middle up to no good.