### PR TITLE
Fix socket connections via url connection string

### DIFF
--- a/spec/pq/conninfo_spec.cr
+++ b/spec/pq/conninfo_spec.cr
@@ -59,6 +59,13 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
     assert_custom_params ci
   end
 
+  it "parses postgres host from socket query string host" do
+    ci = PQ::ConnInfo.from_conninfo_string(
+      "postgresql://user:pass@/db?host=/sql/socket")
+
+    ci.host.should eq "/sql/socket"
+  end
+
   it "parses libpq style strings" do
     ci = PQ::ConnInfo.from_conninfo_string(
       "host=host dbname=db user=user password=pass port=5555 sslmode=require")

--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -68,7 +68,8 @@ module PQ
 
     # Initializes with a `URI`
     def initialize(uri : URI)
-      initialize(uri.hostname, uri.path, uri.user, uri.password, uri.port, :prefer)
+      hostname = uri.hostname.presence || URI::Params.parse(uri.query.to_s).fetch("host", "")
+      initialize(hostname, uri.path, uri.user, uri.password, uri.port, :prefer)
       if q = uri.query
         HTTP::Params.parse(q) do |key, value|
           handle_sslparam(key, value)


### PR DESCRIPTION
When connecting to a postgres instance via socket, the hostname parsed
by URI.parse is left empty, while a query string with the host is added
If the hostname is left blank, fallback to the host provided by the
query string

Resolves #227