### PR TITLE
Refactor `String#split` to `String#partition`

### DIFF
--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -56,10 +56,11 @@ module PQ
         args = Hash(String, String).new
         conninfo.split ' ' do |pair|
           begin
-            k, v = pair.split('=')
+            k, eq, v = pair.partition('=')
+            if eq.empty?
+              raise ArgumentError.new("invalid paramater: #{pair}")
+            end
             args[k] = v
-          rescue IndexError
-            raise ArgumentError.new("invalid paramater: #{pair}")
           end
         end
         new(args)


### PR DESCRIPTION
This is a performance improvement. `partition` doesn't allocate an array.

As a side effect, this also gets rid of rescuing `IndexError` (cf https://github.com/crystal-lang/crystal/issues/11565#issuecomment-1003040007).