### PR TITLE
Properly encode null values in arrays

### DIFF
--- a/spec/pq/param_spec.cr
+++ b/spec/pq/param_spec.cr
@@ -18,6 +18,7 @@ describe PQ::Param do
       it_encodes_array([%(a), %(\\b~), %(c\\"d), %(\uFF8F)], %({"a","\\\\b~","c\\\\\\"d","\uFF8F"}))
       it_encodes_array(["baz, bar"], %({"baz, bar"}))
       it_encodes_array(["foo}"], %({"foo}"}))
+      it_encodes_array([nil, nil], %({NULL,NULL}))
     end
   end
 end

--- a/src/pq/param.cr
+++ b/src/pq/param.cr
@@ -103,6 +103,10 @@ module PQ
       io << value
     end
 
+    def self.encode_array(io, value : Nil)
+      io << "NULL"
+    end
+
     def self.encode_array(io, value : Bool)
       io << (value ? 't' : 'f')
     end


### PR DESCRIPTION
Fixes an error when attempting to insert arrays
containing nil values.

Co-authored-by: Alex Piechowski <alex@piechowski.io>
