### PR TITLE
Drop support for postgres 9.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,6 @@ testdefault: &testdefault
         command: echo 'export DATABASE_URL=postgres://postgres@localhost/postgres' >> $BASH_ENV
     - run: crystal spec --error-on-warnings
 
-noscram: &noscram
-  environment:
-    NOSCRAM: true
-
 jobs:
   postgresql-14:
     <<: *testdefault
@@ -33,9 +29,6 @@ jobs:
     <<: *testdefault
   postgresql-10:
     <<: *testdefault
-  postgresql-9.6:
-    <<: *testdefault
-    <<: *noscram
   check_format:
     docker:
       - image: crystallang/crystal:latest
@@ -52,6 +45,4 @@ workflows:
       - postgresql-12
       - postgresql-11
       - postgresql-10
-      - postgresql-9.6
       - check_format
-

--- a/.circleci/pg_hba.conf
+++ b/.circleci/pg_hba.conf
@@ -4,3 +4,4 @@ host    all       postgres       127.0.0.1/32  trust
 host    all       crystal_md5    127.0.0.1/32  md5
 hostssl all       crystal_ssl    127.0.0.1/32  cert
 host    all       crystal_clear  127.0.0.1/32  password
+host    all       crystal_scram  127.0.0.1/32  scram-sha-256

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -6,11 +6,6 @@ echo "VER=#{$VER}"
 echo "CONF=#{$CONF}"
 
 cp .circleci/pg_hba.conf $CONF
-if [ -v NOSCRAM ]; then
-  echo "not adding scram to pg_hba"
-else
-  echo "host    all       crystal_scram  127.0.0.1/32  scram-sha-256" >> $CONF/pg_hba.conf
-fi
 
 mkdir .cert
 chmod 700 .cert

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v?.?.?     upcoming
 =====================
 * Update crystal-db to 0.11
+* Drop official support for all 9.x versions
 
 v0.25.0    2022-01-27
 =====================


### PR DESCRIPTION
It fell out of support from the postgres project itself on Nov 11 2021,
so stop running CI tests for it. https://www.postgresql.org/support/versioning/

The postgres protocol is still unchanged, so it still probably works
fine however.

Now that all supported versions support scram, the CI setup can be
simplified a bit, which is nice.