### PR TITLE
Add support for extensions like `citext`

### DIFF
--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -1,4 +1,6 @@
 require "uuid"
+# Extensions must be loaded before spec_helper connects to the DB
+require "../../src/pg/extensions/citext"
 require "../spec_helper"
 
 describe PG::Decoders do
@@ -92,4 +94,15 @@ describe PG::Decoders do
   test_decode "path ", "'(1,2,3,4)'::path ", PG::Geo::Path.new([PG::Geo::Point.new(1.0, 2.0), PG::Geo::Point.new(3.0, 4.0)], closed: true)
   test_decode "path ", "'[1,2,3,4,5,6]'::path", PG::Geo::Path.new([PG::Geo::Point.new(1.0, 2.0), PG::Geo::Point.new(3.0, 4.0), PG::Geo::Point.new(5.0, 6.0)], closed: false)
   test_decode "polygon", "'1,2,3,4,5,6'::polygon", PG::Geo::Polygon.new([PG::Geo::Point.new(1.0, 2.0), PG::Geo::Point.new(3.0, 4.0), PG::Geo::Point.new(5.0, 6.0)])
+
+  it "decodes extension types on a per-connection basis" do
+    PG_DB.exec "CREATE EXTENSION IF NOT EXISTS citext"
+    PG_DB.query "select 'OMG lol'::citext" do |rs|
+      rs.each do
+        text = rs.read
+        text.should be_a PG::CIText
+        text.should eq "omg LOL"
+      end
+    end
+  end
 end

--- a/src/pg/extensions.cr
+++ b/src/pg/extensions.cr
@@ -1,0 +1,5 @@
+module PG
+  module Extension
+    abstract def load(connection : Connection)
+  end
+end

--- a/src/pg/extensions/citext.cr
+++ b/src/pg/extensions/citext.cr
@@ -48,6 +48,10 @@ module PG
     def ==(other : String)
       @text.compare(other, case_insensitive: true)
     end
+
+    def to_s(io)
+      @text.to_s io
+    end
   end
 end
 

--- a/src/pg/extensions/citext.cr
+++ b/src/pg/extensions/citext.cr
@@ -1,0 +1,58 @@
+require "../../pg"
+
+module PG
+  module Extension
+    # This extension adds support for decoding the Postgres `citext` type.
+    class CIText
+      include Extension
+
+      def load(connection)
+        oid = connection.query_one "SELECT oid FROM pg_type WHERE typname = 'citext'", as: UInt32
+        connection.register_decoder Decoder.new([oid.to_i])
+      end
+
+      struct Decoder
+        include Decoders::Decoder
+
+        getter oids : Array(Int32)
+
+        def initialize(@oids : Array(Int32))
+        end
+
+        def decode(io, bytesize, oid)
+          PG::CIText.new(Decoders::StringDecoder.new.decode(io, bytesize, oid))
+        end
+
+        def type
+          PG::CIText
+        end
+      end
+    end
+
+    Connection.register_extension CIText.new
+  end
+
+  struct CIText
+    def initialize(text : String)
+      @text = text.downcase
+    end
+
+    def hash(hasher)
+      @text.hash(hasher)
+    end
+
+    def ==(other : self)
+      @text == other.@text
+    end
+
+    def ==(other : String)
+      @text.compare(other, case_insensitive: true)
+    end
+  end
+end
+
+class String
+  def ==(other : PG::CIText)
+    other == self
+  end
+end

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -171,7 +171,7 @@ class PG::ResultSet < ::DB::ResultSet
   end
 
   private def decoder(index = @column_index)
-    Decoders.from_oid(oid(index))
+    statement.connection.decoder(oid(index))
   end
 
   private def oid(index = @column_index)


### PR DESCRIPTION
This PR actually adds a few different things:

- The concept of handling extensions
- An API to register those extensions to prepare new connections for them
- Connection-specific decoders, delegating to the global decoder map
- `citext` as one of those extensions, including a decoder for it and a `PG::CIText` Crystal type

The `CIText` type could just return a string, but I thought it might be confusing to get a case-insensitive string out of the database only for it to do case-sensitive checking later. This type offers the case-insensitive equality checks in Crystal code and also allows you to get the raw string out.

After working on this, I discovered #89 which is quite similar to this PR, but is 5 years old and likely significantly out of date by this point. This is just a draft because it’s still unpolished, but I’m using a monkeypatched version in one of my apps (email addresses are stored as `citext`) and it seems to work.