### PR TITLE
Reuse existing connection for shared specs

### DIFF
--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -13,6 +13,20 @@ private def bytes(*values)
   Slice(UInt8).new(Array(UInt8).new.push(*values.map(&.to_u8)).to_unsafe, values.size)
 end
 
+# Force re-use of existing connection instead of making a new connection each time in the shared specs
+class DB::DriverSpecs(DBAnyType)
+  def with_db(options = nil)
+    @before.call
+    db = PG_DB
+    db.exec(sql_drop_table("table1"))
+    db.exec(sql_drop_table("table2"))
+    db.exec(sql_drop_table("person"))
+    yield db
+  ensure
+    @after.call
+  end
+end
+
 DB::DriverSpecs(DB::Any).run do
   connection_string DB_URL
 


### PR DESCRIPTION
I noticed that the shared specs were making a new connection for every example, which wasn't necessary. Reusing the connection makes the tests to run on my laptop with compile time from an average of 12.275 seconds to 7.877

Nothing is failing now and I think the monkey patch is easy enough to back out should it start causing problems. But maybe there should be an official way to reuse an existing connection for the shared specs?