### PR TITLE
Stop shelling out to whoami

### DIFF
--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -1,5 +1,6 @@
 require "uri"
 require "http"
+require "system/user"
 
 module PQ
   struct ConnInfo
@@ -127,12 +128,12 @@ module PQ
       if db && db != "/"
         db
       else
-        `whoami`.chomp
+        current_user_name
       end
     end
 
     private def default_user(u)
-      u || `whoami`.chomp
+      u || current_user_name
     end
 
     private def default_sslmode(mode)
@@ -152,6 +153,10 @@ module PQ
       else
         raise ArgumentError.new("sslmode #{mode} not supported")
       end
+    end
+
+    private def current_user_name
+      System::User.find_by(id: LibC.getuid.to_s).username
     end
   end
 end


### PR DESCRIPTION
For finding a default username and database name when none is given (eg `postgres:///`), this would previously shell out to running the whoami command. Now it calls libc directly to find the current username.

This was especially slow for the tests before cafe09ed5547 but even now finding this change brings the tests from (avg over 10 runs counting compile time) 7.87 seconds down to 6.94.