### PR TITLE
Silence `_oid` argument warning

### DIFF
--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -83,7 +83,7 @@ module PG
         2950, # UUID
       ]
 
-      def decode(io, bytesize, _oid)
+      def decode(io, bytesize, oid _oid)
         bytes = uninitialized UInt8[16]
 
         slice = Bytes.new(bytes.to_unsafe, 16)


### PR DESCRIPTION
This warning appears on the latest Crystal versions:

    In src/pg/decoder.cr:86:32

     86 | def decode(io, bytesize, _oid)
                                   ^---
    Warning: positional parameter '_oid' corresponds to parameter 'oid' of the overridden method PG::Decoders::Decoder#decode(io, bytesize, oid), which has a different name and may affect named argument passing

If the argument is expoosed outside the method as the name the Crystal compiler expects, this warning goes away. I kept the underscore-prefixed name as the internal variable name so it would remain clear it's not used.