### PR TITLE
Ensure sslmode=disable is respected

### DIFF
--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -33,7 +33,7 @@ module PQ
       end
 
       @soc = soc
-      negotiate_ssl if @soc.is_a?(TCPSocket)
+      negotiate_ssl if @soc.is_a?(TCPSocket) && @conninfo.sslmode != :disable
     end
 
     private def negotiate_ssl


### PR DESCRIPTION
It appears that `crystal-pg` is not compatible with PostgreSQL instances that do not have SSL support, and it seems to be ignoring the `sslmode=disable` parameter. This issue is particularly evident with PostgreSQL databases provisioned in Fly.io since they are accessed over an encrypted internal network, and SSL is not supported in such cases ([ref](https://community.fly.io/t/can-not-connect-to-postgres-sql-ssl-handshake/12093/2)).

To illustrate, I was trying to make this seemingly simple script work:

```crystal
require "db"
require "pg"

DB.connect ENV["DATABASE_URL"] do |cnn|
  p cnn
end
```

And I got the following trace:

<details>
  <summary>Trace</summary>

```
Unhandled exception:  (DB::ConnectionRefused)
  from lib/pg/src/pg/connection.cr:16:9 in 'initialize'
  from lib/pg/src/pg/connection.cr:7:5 in 'new'
  from lib/pg/src/pg/driver.cr:3:5 in 'build_connection'
  from lib/db/src/db.cr:163:5 in 'build_connection'
  from lib/db/src/db.cr:159:5 in 'build_connection'
  from lib/db/src/db.cr:142:5 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:115:5 in 'main_user_code'
  from /usr/share/crystal/src/crystal/main.cr:101:7 in 'main'
  from /usr/share/crystal/src/crystal/main.cr:127:3 in 'main'
  from /lib/x86_64-linux-gnu/libc.so.6 in '??'
  from /lib/x86_64-linux-gnu/libc.so.6 in '__libc_start_main'
  from bin/test in '_start'
  from ???
Caused by: SSL_connect: I/O error (OpenSSL::SSL::Error)
  from /usr/share/crystal/src/openssl/ssl/socket.cr:34:11 in 'initialize:context:sync_close'
  from /usr/share/crystal/src/openssl/ssl/socket.cr:3:5 in 'new:context:sync_close'
  from lib/pg/src/pq/connection.cr:60:16 in 'negotiate_ssl'
  from lib/pg/src/pq/connection.cr:40:7 in 'initialize'
  from lib/pg/src/pq/connection.cr:21:5 in 'new'
  from lib/pg/src/pg/connection.cr:13:23 in 'initialize'
  from lib/pg/src/pg/connection.cr:7:5 in 'new'
  from lib/pg/src/pg/driver.cr:3:5 in 'build_connection'
  from lib/db/src/db.cr:163:5 in 'build_connection'
  from lib/db/src/db.cr:159:5 in 'build_connection'
  from lib/db/src/db.cr:142:5 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:115:5 in 'main_user_code'
  from /usr/share/crystal/src/crystal/main.cr:101:7 in 'main'
  from /usr/share/crystal/src/crystal/main.cr:127:3 in 'main'
  from /lib/x86_64-linux-gnu/libc.so.6 in '??'
  from /lib/x86_64-linux-gnu/libc.so.6 in '__libc_start_main'
  from bin/test in '_start'
  from ???
Caused by: SSL_connect: Resource temporarily unavailable (RuntimeError)
```
</details>

It should be noted that while I was testing this, the `DATABASE_URL` environment variable was complying to the following format: `postgres://<user>:<pwd>@<host>:<port>/<db>?sslmode=disable`.

This seems to indicate that `crystal-pg` is trying to require an SSL connection when it shouldn't.

In this pull request, I am providing a fairly simple fix to this. Let me know if I am missing something or if this is not the right way to go about this!
