### PR TITLE
bugfix: treat PGHOST env var as directory when it's a path

### DIFF
--- a/spec/pq/conninfo_spec.cr
+++ b/spec/pq/conninfo_spec.cr
@@ -132,5 +132,11 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
       ci.port.should eq(1)
       ci.user.should eq("D")
     end
+
+    env_var_bubble do
+      ENV["PGHOST"] = "/path"
+      ci = PQ::ConnInfo.from_conninfo_string("postgres://")
+      ci.host.should eq("/path/.s.PGSQL.5432")
+    end
   end
 end

--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -118,7 +118,9 @@ module PQ
     private def default_host(h)
       return h if h && !h.blank?
 
-      return ENV["PGHOST"] if ENV.has_key?("PGHOST")
+      if pghost = ENV["PGHOST"]?
+        return pghost[0] == '/' ? "#{pghost}/.s.PGSQL.5432" : pghost
+      end
 
       SOCKET_SEARCH.each do |s|
         return s if File.exists?(s)


### PR DESCRIPTION
This change makes the driver find the actual socket file and is consistent with how libpq appends .s.PGSQL.5432 to the value of the env var when it's a path:

    ❯ mkdir -p /tmp/foo && PGHOST=/tmp/foo psql
    psql: error: could not connect to server: No such file or directory
            Is the server running locally and accepting
            connections on Unix domain socket "/tmp/foo/.s.PGSQL.5432"?

When the value is a domain the behavior doesn't change 