### PR TITLE
Fix: statement.connection is a DB::Connection (expected PG::Connection)

### DIFF
--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -15,7 +15,7 @@ class PG::ResultSet < ::DB::ResultSet
     @column_index = -1 # The current column
     @end = false       # Did we read all the rows?
     @rows_affected = 0_i64
-    @sized_io = Buffer.new(conn.soc, 1, statement.connection)
+    @sized_io = Buffer.new(conn.soc, 1, statement.connection.as(PG::Connection))
   end
 
   protected def conn


### PR DESCRIPTION
When requiring multiple database drivers (e.g. `mysql` or `sqlite3` in addition to `pg`), compilation will fail:

```
In lib/pg/src/pg/result_set.cr:18:51

 18 | @sized_io = Buffer.new(conn.soc, 1, statement.connection)
                                                    ^---------
Error: expected argument #3 to 'PG::ResultSet::Buffer.new' to be PG::Connection, not DB::Connection
```

As long as we don't require any other DB driver, `statement.connection` will always be `PG::Connection` as expected, but when requiring multiple drivers, it will be `DB::Connection+`. The solution is to make an explicit cast.