### PR TITLE
fix: timestamp(tz) arithmetic overflow

### DIFF
--- a/spec/pg/decoder_spec.cr
+++ b/spec/pg/decoder_spec.cr
@@ -50,6 +50,9 @@ describe PG::Decoders do
   test_decode "timestamptz", "'2015-02-03 16:15:13-01'::timestamptz",
     Time.utc(2015, 2, 3, 17, 15, 13)
 
+  test_decode "timestamptz", "'0005-02-03 16:15:15-05:17:32'::timestamptz",
+    Time.local(5, 2, 3, 16, 15, 15, location: Time::Location.load("America/Montreal"))
+
   test_decode "timestamptz", "'2015-02-03 16:15:14.23-01'::timestamptz",
     Time.utc(2015, 2, 3, 17, 15, 14, nanosecond: 230_000_000)
 
@@ -60,8 +63,14 @@ describe PG::Decoders do
   test_decode "timestamp", "'2015-02-03 16:15:15'::timestamp",
     Time.utc(2015, 2, 3, 16, 15, 15)
 
+  test_decode "timestamp", "'0005-02-03 16:15:15'::timestamp",
+    Time.utc(5, 2, 3, 16, 15, 15)
+
   test_decode "date", "'2015-02-03'::date",
     Time.utc(2015, 2, 3, 0, 0, 0)
+
+  test_decode "date", "'0005-02-03'::date",
+    Time.utc(5, 2, 3, 0, 0, 0)
 
   # -14706000000 = microseconds in -4 hours, -5 minutes -6 seconds
   test_decode "interval", "'P-1Y-2M3DT-4H-5M-6S'::interval", PG::Interval.new(-14706000000, 3, -14)

--- a/src/pg/decoder.cr
+++ b/src/pg/decoder.cr
@@ -422,9 +422,13 @@ module PG
         in .date?
           JAN_1_2K + read_i32(io).days
         in .timestamp?
-          JAN_1_2K + read_i64(io).microseconds
+          v = read_i64(io) # microseconds
+          sec, m = v.divmod(1_000_000)
+          JAN_1_2K + Time::Span.new(seconds: sec, nanoseconds: m*1000)
         in .timestamptz?
-          time = JAN_1_2K + read_i64(io).microseconds
+          v = read_i64(io) # microseconds
+          sec, m = v.divmod(1_000_000)
+          time = JAN_1_2K + Time::Span.new(seconds: sec, nanoseconds: m*1000)
           time.in io.connection.time_zone
         end
       end


### PR DESCRIPTION
A regression is causing an arithmetic overflow on some timestamp(tz)s.