### PR TITLE
fix: enable SNI

### DIFF
--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -56,7 +56,7 @@ module PQ
         if sslrootcert = @conninfo.sslrootcert
           ctx.ca_certificates = sslrootcert
         end
-        @soc = OpenSSL::SSL::Socket::Client.new(@soc, context: ctx, sync_close: true)
+        @soc = OpenSSL::SSL::Socket::Client.new(@soc, context: ctx, sync_close: true, hostname: @conninfo.host)
       end
 
       if @conninfo.sslmode == :require && !@soc.is_a?(OpenSSL::SSL::Socket::Client)


### PR DESCRIPTION
👋 At Neon, we use SNI to know which database endpoint is being requested to connect to. Our fallback options are using `options` which this library also doesn't support, or using cleartext passwords and encoding the database endpoint into the password. See https://neon.tech/docs/connect/connection-errors#the-endpoint-id-is-not-specified

Reading https://forum.crystal-lang.org/t/specifying-the-sni-hostname-for-an-openssl-context/3872 it seems like enabling SNI wasn't too challenging. Testing locally it does seem to work.