### PR TITLE
Support encoding `PG::Interval` params

### DIFF
--- a/spec/pg/encoder_spec.cr
+++ b/spec/pg/encoder_spec.cr
@@ -41,6 +41,9 @@ describe PG::Driver, "encoder" do
   test_insert_and_read "text[]", ["baz, bar"]
   test_insert_and_read "text[]", ["foo}"]
 
+  test_insert_and_read "interval", PG::Interval.new
+  test_insert_and_read "interval", PG::Interval.new(days: 400, microseconds: 5000000)
+
   describe "geo" do
     test_insert_and_read "point", PG::Geo::Point.new(1.2, 3.4)
     if Helper.db_version_gte(9, 4)

--- a/src/pq/param.cr
+++ b/src/pq/param.cr
@@ -68,6 +68,11 @@ module PQ
       text string
     end
 
+    def self.encode(val : PG::Interval)
+      # https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
+      text "#{val.months} months #{val.days} days #{val.microseconds} microseconds"
+    end
+
     def self.encode(val)
       text val.to_s
     end


### PR DESCRIPTION
Resolves #272.

I opted to encode the `PG::Interval` using the textual representation of a PG interval type, primarily to just have the most accuracy.