### PR TITLE
Encode Crystal enum args as integers

### DIFF
--- a/src/pq/param.cr
+++ b/src/pq/param.cr
@@ -23,6 +23,10 @@ module PQ
       text Time::Format::RFC_3339.format(val, fraction_digits: 9)
     end
 
+    def self.encode(val : Enum)
+      encode val.value
+    end
+
     def self.encode(val : PG::Geo::Point)
       text "(#{val.x},#{val.y})"
     end


### PR DESCRIPTION
_Decoding_ enum values is [already supported in DB](https://github.com/crystal-lang/crystal-db/blob/532ae075bd810cfd0032b74189ec01fcfba2f355/src/db/result_set.cr#L156-L175), but _encoding_ still requires explicitly specifying `enum.value` in query args. This PR uses the `value` property implicitly.

An argument could be made that it would be easier to understand the query if we use the string representations of the Crystal `enum`s instead, but I'm proposing the numeric values for three reasons:

1. An `int4` values takes up less space than a `text`
2. Storing the text representation makes `@[Flags]` enums painful to parse, but the integer representation makes them trivial
3. The `enum` _is_ an `Int32`

Example:

```crystal
require "pg"

struct User
  include DB::Serializable

  getter id : UUID
  getter name : String
  getter role : Role
  getter created_at : Time

  @[Flags]
  enum Role
    Admin      = 0x01
    Moderator  = 0x02
    Subscriber = 0x04
    Member     = 0x08
    Guest      = 0x10
  end
end

pg = DB.open("postgres:///")

sql = "SELECT $1::uuid id, $2 name, $3::int4 role, now() created_at"
args = {
  UUID.v7,                        # $1 id
  "jgaskins",                     # $2 name
  User::Role[:admin, :moderator], # $3 role
}
pp pg.query_one sql, *args, as: User
# User(
#  @created_at=2024-07-21 12:10:33.400016000 -05:00 America/Chicago,
#  @id=UUID(0190d646-0cb7-7d60-82f0-18074e861a46),
#  @name="jgaskins",
#  @role=User::Role[Admin, Moderator])
```