### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -15,7 +15,7 @@ end
 
 # Force re-use of existing connection instead of making a new connection each time in the shared specs
 class DB::DriverSpecs(DBAnyType)
-  def with_db(options = nil)
+  def with_db(options = nil, &)
     @before.call
     db = PG_DB
     db.exec(sql_drop_table("table1"))

--- a/spec/pq/connection_spec.cr
+++ b/spec/pq/connection_spec.cr
@@ -8,7 +8,7 @@ end
 
 describe PQ::Connection, "#server_parameters" do
   it "ParameterStatus frames in response to set are handeled" do
-    get = ->{ PG_DB.using_connection &.connection.server_parameters["standard_conforming_strings"] }
+    get = -> { PG_DB.using_connection &.connection.server_parameters["standard_conforming_strings"] }
     get.call.should eq("on")
     PG_DB.exec "set standard_conforming_strings to on"
     get.call.should eq("on")

--- a/spec/pq/pgpass_spec.cr
+++ b/spec/pq/pgpass_spec.cr
@@ -3,7 +3,7 @@ require "../../src/pq/conninfo"
 require "../../src/pq/pgpass"
 require "log/spec"
 
-def create_empty_pgpass_file
+def create_empty_pgpass_file(&)
   tempfile = File.tempfile("pgpass")
   begin
     File.chmod(tempfile.path, 0o0600)
@@ -13,7 +13,7 @@ def create_empty_pgpass_file
   end
 end
 
-def create_valid_pgpass_file
+def create_valid_pgpass_file(&)
   create_empty_pgpass_file do |filename|
     File.write(filename, <<-PGPASS)
 host:1:database:user:pass
@@ -26,7 +26,7 @@ PGPASS
   end
 end
 
-def create_invalid_pgpass_file
+def create_invalid_pgpass_file(&)
   create_empty_pgpass_file do |filename|
     File.write(filename, "host:1:database:user")
     yield filename

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,13 +4,13 @@ require "../src/pg"
 DB_URL = ENV["DATABASE_URL"]? || "postgres:///"
 PG_DB  = DB.open(DB_URL)
 
-def with_db
+def with_db(&)
   DB.open(DB_URL) do |db|
     yield db
   end
 end
 
-def with_connection
+def with_connection(&)
   DB.connect(DB_URL) do |conn|
     yield conn
   end
@@ -60,7 +60,7 @@ def test_decode(name, query, expected : JSON::PullParser, file = __FILE__, line 
   end
 end
 
-def env_var_bubble
+def env_var_bubble(&)
   orig_vals = Hash(String, String).new
   vars = ["PGDATABASE", "PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGPASSFILE"]
   begin

--- a/src/pg/result_set.cr
+++ b/src/pg/result_set.cr
@@ -138,7 +138,7 @@ class PG::ResultSet < ::DB::ResultSet
     JSON::Any.new(value) if value
   end
 
-  private def read_array(t : T.class) : T forall T
+  private def read_array(t : T.class, &) : T forall T
     col_bytesize = conn.read_i32
     if col_bytesize == -1
       @column_index += 1
@@ -152,7 +152,7 @@ class PG::ResultSet < ::DB::ResultSet
     raise DB::ConnectionLost.new(statement.connection, cause: e)
   end
 
-  private def safe_read(col_bytesize)
+  private def safe_read(col_bytesize, &)
     @sized_io.read_remaining = col_bytesize.to_u64
 
     begin

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -90,7 +90,7 @@ module PQ
       end
     end
 
-    def synchronize
+    def synchronize(&)
       @mutex.synchronize { yield }
     end
 
@@ -149,7 +149,7 @@ module PQ
       soc.flush
     end
 
-    def read_data_row
+    def read_data_row(&)
       size = read_i32
       ncols = read_i16
       row = Array(Slice(UInt8)?).new(ncols.to_i32) do
@@ -432,7 +432,7 @@ module PQ
       end
     end
 
-    def read_all_data_rows
+    def read_all_data_rows(&)
       type = soc.read_char
       loop do
         break unless type == 'D'

--- a/src/pq/query.cr
+++ b/src/pq/query.cr
@@ -32,7 +32,7 @@ module PQ
       @got_data = false
     end
 
-    def get_data
+    def get_data(&)
       raise "already read data" if @got_data
       if @has_data
         conn.read_all_data_rows { |row| yield row }


### PR DESCRIPTION
Crystal nightly has a couple new formatter rules enabled: https://github.com/crystal-lang/crystal/pull/14718
The changes are backwards-compatible, so Crystal 1.14.0 won't complain about the new format.