### PR TITLE
Handle `Array(Bytes)` encoding for query params containing non-Unicode text

### DIFF
--- a/spec/pq/param_spec.cr
+++ b/spec/pq/param_spec.cr
@@ -16,6 +16,7 @@ describe PQ::Param do
       it_encodes_array([1, 2, 3], "{1,2,3}")
       it_encodes_array([1.2, 3.4, 5.6], "{1.2,3.4,5.6}")
       it_encodes_array([%(a), %(\\b~), %(c\\"d), %(\uFF8F)], %({"a","\\\\b~","c\\\\\\"d","\uFF8F"}))
+      it_encodes_array([%(this is a "slice").to_slice], %({"\\\\x7468697320697320612022736c69636522"}))
       it_encodes_array(["baz, bar"], %({"baz, bar"}))
       it_encodes_array(["foo}"], %({"foo}"}))
       it_encodes_array([nil, nil], %({NULL,NULL}))

--- a/src/pq/param.cr
+++ b/src/pq/param.cr
@@ -121,8 +121,10 @@ module PQ
     end
 
     def self.encode_array(io, value : Bytes)
-      io << '"'
-      io << String.new(value).gsub(%("), %(\\"))
+      io << %{"\\\\x}
+      value.each do |byte|
+        byte.to_s io, base: 16, precision: 2
+      end
       io << '"'
     end
 


### PR DESCRIPTION
Ran into #267 tonight trying to bulk-insert MessagePack-encoded data (via `unnest`) and can confirm that it's `Array(Bytes)` that it's choking on. Since all arrays are text-encoded, we need to ensure text encoding for `Bytes` can handle binary data.

I tried special-casing `Array(Bytes)` all the way down, but not only does that require a lot more understanding of the binary encoding format than I currently have, it would've been an incomplete solution that only handles linear `bytea` arrays. Anyone using nested arrays would run into the same problem. So I decided against that.

I don't like that this solution increases the payload size over the wire by encoding every byte as 2 hexadecimal characters. Arrays of strings are implemented in terms of this method, so this impacts `text[]` encoding, but it doesn't impact encoding of strings _outside_ of arrays, so performance impact should be minimal for most use cases. And every other PQ implementation I've found so far, other than `libpq` itself, also uses the hex encoding so it seems that if we're slow we're at least in good company. I think my ideal solution would be to convert all param types to binary encoding, but this was a far easier step and I couldn't find the specification for the binary encoding and it's late and I'm sleeeeeeepy.

Please check my work on this. I did confirm that the test case deserializes into the expected string:

```crystal
db.query_each "SELECT '\\x7468697320697320612022736c69636522'::bytea" do |rs|
  puts String.new rs.read(Bytes)
end
# => this is a "slice"
```

… and my MessagePack-encoded data unpacks correctly after bulk-inserting it now, but I'm not confident there isn't something I've overlooked.

Fixes #267