### PR TITLE
windows: avoid breaking Libc.getuid call

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ v? upcoming
 * Support encoding PG::Interval params (thanks @Blacksmoke16)
 * Encode Crystal enum args as integers (thanks @jgaskins)
 * Handle Array(Bytes) encoding for query params containing non-Unicode text (thanks @jgaskins)
+* Avoid calling LibC.getuid on windows
 
 
 v0.28.0    2023-12-21

--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -171,7 +171,13 @@ module PQ
     end
 
     private def current_user_name
-      System::User.find_by(id: LibC.getuid.to_s).username
+      {% if flag?(:windows) %}
+        # NOTE: actually getting the current username on windows would be better
+        #       https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getusernamew
+        "postgres"
+      {% else %}
+        System::User.find_by(id: LibC.getuid.to_s).username
+      {% end %}
     end
   end
 end


### PR DESCRIPTION
partially address #291

@jwoertink does this make it not crash at least? I don't have a windows install to test on myself