### PR TITLE
`PQ::Connection#send_bind_message`: write entire slice to socket at once

### DIFF
--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -498,7 +498,7 @@ module PQ
       write_i16 nparams # number of params to follow
       params.each do |p|
         write_i32 p.size
-        p.slice.each { |byte| write_byte byte }
+        soc.write(p.slice)
       end
       write_i16 1 # number of following return types (1 means apply next for all)
       write_i16 result_format


### PR DESCRIPTION
TLDR: ~2x to ~10x+  speedup when sending large query parameters, simply by doing `soc.write(p.slice)` instead of `p.slice.each { |byte| write_byte byte }`. 🐰 

-----

## Benchmark results

| Parameter Size | Speedup (type=Bytes) | Speedup (type=String) |
| --- | --- | --- |
| 16 MiB | 2.66x | 1.97x |
| 4 MiB | 14.34x | 2.74x |
| 1 MiB | 11.86x | 2.94x |
| 128 kiB | 6.68x | 2.50x |
| 8 kiB | 1.68x | 1.56x |

**BEFORE THIS PR**

```
       0 Bytes   40.95k ( 24.42µs) (± 2.65%)  592B/op
       1 Bytes   41.74k ( 23.96µs) (± 1.75%)  592B/op
      16 Bytes   41.44k ( 24.13µs) (± 1.60%)  592B/op
     256 Bytes   37.74k ( 26.50µs) (± 7.59%)  592B/op
    1024 Bytes   35.04k ( 28.54µs) (± 5.90%)  592B/op
    8192 Bytes   19.44k ( 51.44µs) (± 0.50%)  592B/op
  131072 Bytes    2.39k (419.15µs) (± 0.44%)  595B/op
 1048576 Bytes  310.64  (  3.22ms) (± 0.46%)  594B/op
 4194304 Bytes   77.89  ( 12.84ms) (± 1.12%)  558B/op
16777216 Bytes   15.18  ( 65.88ms) (± 1.41%)  726B/op
       0 String  37.37k ( 26.76µs) (± 0.57%)  576B/op
       1 String  37.12k ( 26.94µs) (± 0.68%)  576B/op
      16 String  37.31k ( 26.80µs) (± 0.46%)  576B/op
     256 String  35.12k ( 28.47µs) (± 1.22%)  576B/op
    1024 String  31.03k ( 32.23µs) (± 1.34%)  576B/op
    8192 String  15.03k ( 66.54µs) (± 4.07%)  576B/op
  131072 String   1.65k (607.25µs) (± 0.97%)  578B/op
 1048576 String 198.94  (  5.03ms) (± 0.58%)  545B/op
 4194304 String  53.69  ( 18.62ms) (± 1.70%)  640B/op
16777216 String  10.65  ( 93.94ms) (± 4.81%)  285B/op
```

**AFTER THIS PR**

```
       0 Bytes   36.63k ( 27.30µs) (± 0.59%)  592B/op
       1 Bytes   37.84k ( 26.42µs) (± 4.97%)  592B/op
      16 Bytes   40.12k ( 24.92µs) (± 3.10%)  592B/op
     256 Bytes   39.29k ( 25.45µs) (± 2.55%)  592B/op
    1024 Bytes   38.47k ( 26.00µs) (± 4.39%)  592B/op
    8192 Bytes   32.57k ( 30.70µs) (± 6.52%)  592B/op
  131072 Bytes   15.93k ( 62.79µs) (± 6.37%)  592B/op
 1048576 Bytes    3.68k (271.48µs) (± 1.92%)  592B/op
 4194304 Bytes    1.12k (895.42µs) (±12.25%)  590B/op
16777216 Bytes   40.44  ( 24.73ms) (± 0.96%)  493B/op
       0 String  36.53k ( 27.38µs) (± 2.18%)  576B/op
       1 String  34.27k ( 29.18µs) (± 8.41%)  576B/op
      16 String  32.86k ( 30.43µs) (± 6.98%)  576B/op
     256 String  36.04k ( 27.75µs) (± 3.35%)  576B/op
    1024 String  34.84k ( 28.70µs) (± 1.24%)  576B/op
    8192 String  23.51k ( 42.53µs) (± 0.37%)  576B/op
  131072 String   4.12k (242.95µs) (± 0.37%)  577B/op
 1048576 String 585.55  (  1.71ms) (± 0.45%)  563B/op
 4194304 String 146.99  (  6.80ms) (± 1.17%)  569B/op
16777216 String  20.93  ( 47.79ms) (± 0.89%)  585B/op
```

-----

## Benchmark script

Run with `crystal run --release send_bind_params_benchmark.cr`

I tested this locally with the `postgres:17.2` docker container and connecting via unix socket.

My script intentionally avoids doing any storage of the parameter to highlight the time to transmit the query.

```crystal
require "benchmark"
require "random"
require "./src/pg"

MAX_PARAM_SIZE      = 16*1024*1024
RANDOM_BYTES        = Random.new.random_bytes(MAX_PARAM_SIZE)
RANDOM_ASCII_STRING = Random.new.hex(MAX_PARAM_SIZE >> 1)

TEST_SIZES   = [0, 1, 16, 256, 1024, 8*1024, 128*1024, 1024*1024, 4*1024*1024, MAX_PARAM_SIZE]
TEST_BYTES   = TEST_SIZES.map { |s| RANDOM_BYTES[0...s] }
TEST_STRINGS = TEST_SIZES.map { |s| RANDOM_ASCII_STRING[0...s] }

PG_DB = DB.open("postgres:///")
puts PG_DB.query_one("SELECT version()", as: String)
PG_DB.exec("set work_mem = '128MB'")

Benchmark.ips(warmup: 0.1.seconds, calculation: 1.0.seconds) do |x|
  TEST_SIZES.each_with_index do |test_size, test_index|
    x.report("#{test_size} Bytes ") do
      PG_DB.exec("select length($1::bytea)", args: [TEST_BYTES[test_index]])
    end
  end
  TEST_SIZES.each_with_index do |test_size, test_index|
    x.report("#{test_size} String") do
      PG_DB.exec("select length($1::varchar)", args: [TEST_STRINGS[test_index]])
    end
  end
end
```