### PR TITLE
Add `pg` log source to log entries.

### DIFF
--- a/spec/pq/pgpass_spec.cr
+++ b/spec/pq/pgpass_spec.cr
@@ -57,7 +57,7 @@ describe PQ::PgPass, ".parsing" do
       create_valid_pgpass_file do |filename|
         File.chmod(filename, 0o0700)
         ENV["PGPASSFILE"] = filename
-        Log.capture {
+        Log.capture("pg") {
           ci = PQ::ConnInfo.from_conninfo_string("postgres://")
         }.itself
           .check(:warn, "Cannot use pgpass file - permissions are inappropriate must be 0600 or less")
@@ -70,7 +70,7 @@ describe PQ::PgPass, ".parsing" do
     env_var_bubble do
       create_invalid_pgpass_file do |filename|
         ENV["PGPASSFILE"] = filename
-        Log.capture {
+        Log.capture("pg") {
           ci = PQ::ConnInfo.from_conninfo_string("postgres://")
         }.itself
           .check(:warn, "PGPass file does not appear to be properly formatted - errors may occur")

--- a/src/pq/pgpass.cr
+++ b/src/pq/pgpass.cr
@@ -1,4 +1,6 @@
 module PQ
+  Log = ::Log.for("pg")
+
   class PgPass
     def self.locate(host : String, port : Int, db : String, user : String) : String?
       filename = ENV.fetch("PGPASSFILE", Path["~/.pgpass"].expand(home: true).to_s)


### PR DESCRIPTION
Even the only module emitting logs is named `PQ` because of postgres libpq, etc... IMO it makes more sense to use the shard name as log source, or maybe `pg.pq`, since most people consuming this log entry will thing that `pq` was a typo for `pg` 😅 
