### PR TITLE
Handle connection string for unix sockets correctly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ v? upcoming
 * Add support for COPY (thanks @17dec)
 * Add pg log source to log entries (thanks @hugopl)
 * Update crystal-db to 0.14 (thanks @bcardiff)
+* Handle connections strings with unix domain sockets correctly (thanks @samu698)
 
 v0.29.0    2024-11-05
 =====================

--- a/spec/pq/conninfo_spec.cr
+++ b/spec/pq/conninfo_spec.cr
@@ -140,7 +140,7 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
     env_var_bubble do
       ENV["PGHOST"] = "/path"
       ci = PQ::ConnInfo.from_conninfo_string("postgres://")
-      ci.host.should eq("/path/.s.PGSQL.5432")
+      ci.host.should eq("/path")
     end
   end
 end

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -22,8 +22,10 @@ module PQ
 
     def initialize(@conninfo : ConnInfo)
       begin
-        if @conninfo.host[0] == '/'
-          soc = UNIXSocket.new(@conninfo.host)
+        if Path.new(@conninfo.host).absolute?
+          socket_name = ".s.PGSQL.#{@conninfo.port}"
+          socket_path = File.join(@conninfo.host, socket_name)
+          soc = UNIXSocket.new(socket_path)
         else
           soc = TCPSocket.new(@conninfo.host, @conninfo.port)
         end


### PR DESCRIPTION
When using connection strings with unix sockets the path should be interpreted as the path to the directory that contains the unix socket rather than the path to socket itself as per spec here:
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-HOST
> Name of host to connect to. If a host name looks like an absolute path name, it specifies Unix-domain communication rather than TCP/IP communication; **the value is the name of the directory in which the socket file is stored.**

The port also can be specified in the URI parameters, as per spec:
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-PORT
> Port number to connect to at the server host, **or socket file name extension for Unix-domain connections.**

The name of the socket is based on the configured port in PostgreSQL this PR also handles this case by generating the socket file name based on the specified port.
https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-UNIX-SOCKET-DIRECTORIES
> In addition to the socket file itself, which is named `.s.PGSQL.nnnn` where `nnnn` is the server's port number

This change would be breaking for current users that rely on current behavior, I can fix this by supporting both possibilities, but this would add complexity and support an out of spec behavior.

Fixes: #297