### PR TITLE
Tier 0: fix mechanical blockers — Interval#to_spans, startup/password bytesize, replication debug noise, CI branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request: {}
   workflow_dispatch: {}
 jobs:

--- a/spec/pg/interval_spec.cr
+++ b/spec/pg/interval_spec.cr
@@ -52,4 +52,24 @@ describe PG::Interval do
       interval.to_month_span.should eq(Time::MonthSpan.new(123))
     end
   end
+
+  describe "to_spans" do
+    it "splits an interval with months into a Time::Span and a Time::MonthSpan" do
+      # 2 months, 3 days, 4 hours
+      interval = PG::Interval.new(microseconds: 4_i64 * 3600 * 1_000_000, days: 3, months: 2)
+      interval.to_spans.should eq({Time::Span.new(days: 3, hours: 4), Time::MonthSpan.new(2)})
+    end
+
+    it "round-trips through a Time" do
+      interval = PG::Interval.new(microseconds: 4_i64 * 3600 * 1_000_000, days: 3, months: 2)
+      span, month_span = interval.to_spans
+      base = Time.utc(2024, 1, 31, 0, 0, 0)
+      (base + span + month_span).should eq(Time.utc(2024, 4, 3, 4, 0, 0))
+    end
+
+    it "works for an interval without months" do
+      interval = PG::Interval.new(microseconds: 0, days: 5, months: 0)
+      interval.to_spans.should eq({Time::Span.new(days: 5), Time::MonthSpan.new(0)})
+    end
+  end
 end

--- a/spec/pg/replication/error_frame_spec.cr
+++ b/spec/pg/replication/error_frame_spec.cr
@@ -1,0 +1,23 @@
+require "../../spec_helper"
+
+describe PG::Replication::ErrorFrame do
+  it "decodes severity, message, detail and hint" do
+    body = IO::Memory.new
+    body << 'S' << "ERROR" << '\0'
+    body << 'M' << "boom" << '\0'
+    body << 'D' << "the detail" << '\0'
+    body << 'H' << "a hint" << '\0'
+    body.write_byte 0_u8
+
+    io = IO::Memory.new
+    io.write_bytes(body.size.to_i32 + 4, IO::ByteFormat::NetworkEndian) # length prefix
+    io.write body.to_slice
+    io.rewind
+
+    frame = PG::Replication::ErrorFrame.new(io)
+    frame.severity.should eq(PG::Replication::Severity::ERROR)
+    frame.message.should eq("boom")
+    frame.detail.should eq("the detail")
+    frame.hint.should eq("a hint")
+  end
+end

--- a/spec/pq/connection_spec.cr
+++ b/spec/pq/connection_spec.cr
@@ -25,4 +25,12 @@ describe PQ::Connection do
     PG_DB.query("") { }
     PG_DB.query_one("select 1", &.read).should eq(1)
   end
+
+  it "encodes a multi-byte application_name in the startup packet" do
+    # Verify the startup packet is accepted when application_name contains
+    # multi-byte UTF-8 characters (bytesize ≠ size; é is 2 bytes in UTF-8).
+    DB.open("#{DB_URL}?application_name=café") do |db|
+      db.scalar("select 1").should eq(1)
+    end
+  end
 end

--- a/src/pg/interval.cr
+++ b/src/pg/interval.cr
@@ -32,11 +32,11 @@ module PG
       Time::MonthSpan.new(months)
     end
 
+    # Decompose into a `Time::Span` (days + sub-day part) and a `Time::MonthSpan`
+    # (months). Adding both to a `Time` reproduces the interval exactly, without
+    # approximating months to days.
     def to_spans
-      {
-        to_time_span,
-        to_time_month_span,
-      }
+      {to_span(approx_months: 0), to_month_span}
     end
   end
 end

--- a/src/pg/replication/error_frame.cr
+++ b/src/pg/replication/error_frame.cr
@@ -7,7 +7,7 @@ module PG::Replication
     getter misc = [] of {Char, String}
 
     def initialize(io : IO)
-      size = read(io, Int32)
+      read(io, Int32) # message length; fields below are null-terminated
       loop do
         case byte = read(io, UInt8)
         when 0   then return

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -148,7 +148,7 @@ module PQ
     end
 
     def startup(args : Array(String))
-      len = args.reduce(0) { |acc, arg| acc + arg.size + 1 }
+      len = args.reduce(0) { |acc, arg| acc + arg.bytesize + 1 }
       write_i32 len + 8 + 1
       write_i32 0x30000
       args.each { |arg| soc << arg << '\0' }
@@ -483,7 +483,7 @@ module PQ
     def send_password_message(password)
       write_chr 'p'
       if password
-        write_i32 password.size + 4 + 1
+        write_i32 password.bytesize + 4 + 1
         soc << password
       else
         write_i32 4 + 1


### PR DESCRIPTION
Part of the road-to-1.0 audit in #307. This is **PR 1 of the Tier 0 work** — the mechanical blockers: things that pass `crystal build` but break when the path is exercised, or silently never run. Each fix lands with a failing-first spec.

## Fixes

- **`PG::Interval#to_spans` referenced undefined methods** (`to_time_span` / `to_time_month_span`) and could not compile the moment it was called. It now returns `{to_span(approx_months: 0), to_month_span}` — a lossless decomposition (time part → `Time::Span`, months → `Time::MonthSpan`, no month→day approximation), pinned by a round-trip spec (`2024-01-31 + 2mo + 3d + 4h == 2024-04-03 04:00:00`).
- **Startup & password length prefixes used `String#size` instead of `#bytesize`** (`src/pq/connection.cr`), under-counting the length for any non-ASCII `user` / `database` / `application_name` / `password` and corrupting the packet. Two one-line fixes + a multi-byte `application_name` spec.
- **Replication debug noise**: removed a stray `pp size: size` in `error_frame.cr` (it printed on every error frame) and a dead `IO::Memory` allocation in `copy_data.cr`. Added the first unit spec for `ErrorFrame` decoding.
- **CI never ran on pushes**: the workflow triggered on `main`, but the default branch is `master`, so push builds never fired. Changed to `master`.

## Notes

- **Scope**: strictly these four blockers. Blocker 0.5 from the audit (a decode error can leave a pooled connection in a desynced wire state — related to #196) is intentionally deferred to a follow-up PR, since it changes connection-state handling and deserves its own discussion.
- **Test assertion detail**: the multi-byte `application_name` spec asserts the connection is *accepted* rather than reading the value back. Under a C-locale UTF8 server — which is what the test setup (`flake.nix` → `initdb --no-locale --encoding=UTF8`) produces — PostgreSQL byte-escapes non-ASCII GUC output on every read path (`SHOW` / `current_setting` / `pg_stat_activity`), so a value round-trip can't be asserted portably. Without the fix the malformed startup packet is rejected (connection refused), so connection-acceptance is the real discriminating signal.
- Full spec suite green locally, including the auth and replication specs.

> ℹ️ Transparency: these fixes came out of an audit produced with Claude Opus 4.8 [1M]; the compile/wire-format findings and each fix were verified by hand against the source and behind specs.
