### PR TITLE
Implement sslmode=verify-ca and verify-full (real TLS certificate verification)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,8 @@
             openssl req -new -nodes -text -out ca.csr -keyout ca-key.pem -subj "/CN=certificate-authority"
             openssl x509 -req -in ca.csr -text -signkey ca-key.pem -out ca-cert.pem
             openssl req -new -nodes -text -out server.csr -keyout server-key.pem -subj "/CN=pg-server"
-            openssl x509 -req -in server.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem
+            echo "subjectAltName=IP:127.0.0.1" > san.ext
+            openssl x509 -req -in server.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -extfile san.ext -out server-cert.pem
             openssl req -new -nodes -text -out client.csr -keyout client-key.pem -subj "/CN=crystal_ssl"
             openssl x509 -req -in client.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out client-cert.pem
 

--- a/spec/pq/conninfo_spec.cr
+++ b/spec/pq/conninfo_spec.cr
@@ -144,3 +144,25 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
     end
   end
 end
+
+describe "#ssl_root_cert" do
+  it "prefers the explicit sslrootcert param" do
+    ci = PQ::ConnInfo.from_conninfo_string("postgres:///db?sslrootcert=/tmp/explicit.pem")
+    ci.ssl_root_cert.should eq("/tmp/explicit.pem")
+  end
+
+  it "falls back to PGSSLROOTCERT when no param is given" do
+    with_env({"PGSSLROOTCERT" => "/tmp/from-env.pem"}) do
+      ci = PQ::ConnInfo.from_conninfo_string("postgres:///db")
+      ci.ssl_root_cert.should eq("/tmp/from-env.pem")
+    end
+  end
+
+  it "is nil when nothing is configured and ~/.postgresql/root.crt is absent" do
+    ci = PQ::ConnInfo.from_conninfo_string("postgres:///db")
+    # only assert nil when the environment genuinely has no root cert configured
+    unless ENV["PGSSLROOTCERT"]? || File.exists?(Path.home.join(".postgresql", "root.crt"))
+      ci.ssl_root_cert.should be_nil
+    end
+  end
+end

--- a/spec/pq/ssl_verify_spec.cr
+++ b/spec/pq/ssl_verify_spec.cr
@@ -1,0 +1,50 @@
+require "../spec_helper"
+
+# Gated like the auth specs: only runs when CRYSTAL_PG_CERT_DIR points at the
+# test certs (set by the nix CI / the local tempdb helper). The server must be
+# started with ssl=on and a server cert whose SAN is IP:127.0.0.1, signed by
+# $CRYSTAL_PG_CERT_DIR/ca-cert.pem.
+#
+# All cases connect over 127.0.0.1 (always listening, and matching the cert
+# SAN). The core security property — that an untrusted CA is rejected — is
+# exercised for both verify-ca and verify-full. Two things are intentionally
+# NOT asserted here because they cannot be tested reliably on loopback:
+#   * verify-full rejecting a hostname mismatch (needs a non-SAN DNS name that
+#     resolves to the listening address; loopback name resolution is
+#     nondeterministic — `localhost` may resolve to ::1 — so it is flaky);
+#   * verify-ca skipping the IP identity check (needs a reachable IP not in the
+#     SAN; the only loopback candidate, ::1, currently hangs the driver on
+#     connect — separate IPv6/connect-timeout issue).
+if certs = ENV["CRYSTAL_PG_CERT_DIR"]?
+  ssl_port = ENV["PGPORT"]? || "5432"
+  ssl_ca = File.join(certs, "ca-cert.pem")
+  ssl_db = PG_DB.query_one("select current_database()", &.read)
+
+  describe PQ::Connection, "sslmode=verify-full" do
+    it "connects with a trusted CA and a matching host" do
+      DB.open("postgres://postgres@127.0.0.1:#{ssl_port}/#{ssl_db}?sslmode=verify-full&sslrootcert=#{ssl_ca}") do |db|
+        db.scalar("select 1").should eq(1)
+      end
+    end
+
+    it "fails when the server CA is untrusted (system store only)" do
+      expect_raises(DB::ConnectionRefused) do
+        DB.open("postgres://postgres@127.0.0.1:#{ssl_port}/#{ssl_db}?sslmode=verify-full")
+      end
+    end
+  end
+
+  describe PQ::Connection, "sslmode=verify-ca" do
+    it "connects with a trusted CA" do
+      DB.open("postgres://postgres@127.0.0.1:#{ssl_port}/#{ssl_db}?sslmode=verify-ca&sslrootcert=#{ssl_ca}") do |db|
+        db.scalar("select 1").should eq(1)
+      end
+    end
+
+    it "fails when the server CA is untrusted" do
+      expect_raises(DB::ConnectionRefused) do
+        DB.open("postgres://postgres@127.0.0.1:#{ssl_port}/#{ssl_db}?sslmode=verify-ca")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -60,6 +60,25 @@ def test_decode(name, query, expected : JSON::PullParser, file = __FILE__, line 
   end
 end
 
+def with_env(values : Hash(String, String), &)
+  old_values = {} of String => String?
+  begin
+    values.each do |key, value|
+      old_values[key] = ENV[key]?
+      ENV[key] = value
+    end
+    yield
+  ensure
+    old_values.each do |key, old_value|
+      if old_value
+        ENV[key] = old_value
+      else
+        ENV.delete(key)
+      end
+    end
+  end
+end
+
 def env_var_bubble(&)
   orig_vals = Hash(String, String).new
   vars = ["PGDATABASE", "PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGPASSFILE"]

--- a/src/ext/openssl.cr
+++ b/src/ext/openssl.cr
@@ -1,5 +1,39 @@
 require "openssl"
 
+lib LibCrypto
+  # Returns the X509_VERIFY_PARAM associated with an X509_STORE_CTX.
+  # Available since OpenSSL 1.0.2 / LibreSSL.
+  fun x509_store_ctx_get0_param = X509_STORE_CTX_get0_param(ctx : X509_STORE_CTX) : X509VerifyParam
+end
+
+class OpenSSL::SSL::Context::Client
+  # sslmode=verify-ca: verify the certificate chain against the trusted CA
+  # store but NOT the hostname. SNI is still sent (the socket is created with
+  # `hostname:`); this callback replaces the built-in chain+hostname
+  # verification with chain-only. The proc captures nothing, so a constant is
+  # GC-safe.
+  private VERIFY_CA_CHAIN_ONLY = ->(x509_ctx : LibCrypto::X509_STORE_CTX, _arg : Void*) do
+    # Clear the hostname check that Socket::Client set on the SSL param (from
+    # the `hostname:` we pass for SNI), so x509_verify_cert validates only the
+    # certificate chain — no hostname check, per sslmode=verify-ca semantics.
+    #
+    # Limitation: when the connection target is an IP literal, Socket::Client
+    # sets an IP check (X509_VERIFY_PARAM_set1_ip_asc) instead of a hostname.
+    # We do not clear that here, so verify-ca to an IP that is not in the
+    # server cert's SAN is still rejected. That is stricter than libpq (fail
+    # closed, no security weakening) and is a rare case; clearing the IP param
+    # via a NULL argument is not viable (it hangs the handshake).
+    param = LibCrypto.x509_store_ctx_get0_param(x509_ctx)
+    LibCrypto.x509_verify_param_set1_host(param, nil, 0)
+    LibCrypto.x509_verify_cert(x509_ctx) == 1 ? 1 : 0
+  end
+
+  def verify_ca_chain_only! : Nil
+    self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
+    LibSSL.ssl_ctx_set_cert_verify_callback(@handle, VERIFY_CA_CHAIN_ONLY, Pointer(Void).null)
+  end
+end
+
 class OpenSSL::X509::Certificate
   def scram_signature
     # The TLS server's certificate bytes need to be hashed with SHA-256 if

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -49,16 +49,28 @@ module PQ
 
       if process_ssl_message
         ctx = OpenSSL::SSL::Context::Client.new
-        ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE # currently emulating sslmode 'require' not verify_ca or verify_full
         if sslcert = @conninfo.sslcert
           ctx.certificate_chain = sslcert
         end
         if sslkey = @conninfo.sslkey
           ctx.private_key = sslkey
         end
-        if sslrootcert = @conninfo.sslrootcert
-          ctx.ca_certificates = sslrootcert
+
+        case @conninfo.sslmode
+        when :"verify-full"
+          ctx.verify_mode = OpenSSL::SSL::VerifyMode::PEER
+          if ca = @conninfo.ssl_root_cert
+            ctx.ca_certificates = ca
+          end
+        when :"verify-ca"
+          if ca = @conninfo.ssl_root_cert
+            ctx.ca_certificates = ca
+          end
+          ctx.verify_ca_chain_only!
+        else
+          ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE
         end
+
         @soc = OpenSSL::SSL::Socket::Client.new(@soc, context: ctx, sync_close: true, hostname: @conninfo.host)
       end
 

--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -35,6 +35,16 @@ module PQ
     # The sslrootcert. Optional.
     getter sslrootcert : String?
 
+    # Resolve the root certificate for sslmode=verify-ca/verify-full:
+    # explicit `sslrootcert`, else PGSSLROOTCERT, else ~/.postgresql/root.crt,
+    # else nil (the system CA store is used by default).
+    def ssl_root_cert : String?
+      @sslrootcert || ENV["PGSSLROOTCERT"]? || begin
+        default = Path.home.join(".postgresql", "root.crt")
+        File.exists?(default) ? default.to_s : nil
+      end
+    end
+
     # The application name. Optional (defaults to "crystal").
     getter application_name : String
 


### PR DESCRIPTION
Part of the road-to-1.0 audit in #307 (Tier 1, security). Closes #240; helps #237 / #231.

Previously `sslmode=verify-ca` and `sslmode=verify-full` were *accepted* but the TLS context was hard-coded to `OpenSSL::SSL::VerifyMode::NONE` — so a user asking for `verify-full` got an **unauthenticated** TLS channel with no certificate or hostname verification (a silent MITM exposure). This implements real verification for both modes.

## What changed

- **`verify-full`** → `VerifyMode::PEER` + CA, and the socket is created with `hostname:`, so OpenSSL enforces both the certificate chain and the hostname/IP.
- **`verify-ca`** → verifies the certificate chain only (no hostname), via a custom cert-verify callback that clears the host check, **while still sending SNI** (the socket still gets `hostname:`).
- **`disable` / `allow` / `prefer` / `require`** → unchanged (`NONE`); the existing `require` "server must offer SSL" backstop is kept.
- **Root certificate resolution** (`PQ::ConnInfo#ssl_root_cert`): explicit `sslrootcert` → `PGSSLROOTCERT` → `~/.postgresql/root.crt` → the system CA store (already loaded by `OpenSSL::SSL::Context::Client`). So `verify-full` works out of the box against servers with a publicly-trusted cert, and with a private CA when one is provided.

## Tests

New `spec/pq/ssl_verify_spec.cr` (gated on `CRYSTAL_PG_CERT_DIR`, like the existing auth specs): for both `verify-ca` and `verify-full`, a trusted CA connects and an **untrusted CA is rejected** (`DB::ConnectionRefused`) — i.e. verification genuinely happens. `flake.nix`'s test server cert gains `subjectAltName=IP:127.0.0.1` so `verify-full` can be exercised against `127.0.0.1`. Unit tests cover the root-cert resolution order. Full suite green.

## Known limitations (documented in-code)

- **`verify-ca` to an IP literal** that is *not* in the server cert's SAN is still rejected (the callback clears the hostname check but not the IP check — clearing the IP param via a NULL argument hangs the handshake). This is **fail-closed** (stricter than libpq, no security weakening) and a rare case; `verify-ca` to a hostname, or to a matching IP, works.
- A couple of negative cases (hostname-mismatch rejection; the `verify-ca` IP-skip) are not asserted in the suite because they require a loopback name/address that the driver currently can't connect to without hanging (a separate connect-timeout / IPv6-host issue, out of scope here).

Scope is strictly server-certificate verification. Client-certificate auth (the pending `ssl clientcert` spec) is intentionally left to a follow-up, though the SAN cert added here is a step toward enabling it.

> ℹ️ Transparency: produced with Claude Opus 4.8 [1M]; the OpenSSL/TLS behavior was verified by hand against the Crystal stdlib and exercised behind specs against a CI-faithful local server.
