### PR TITLE
Implement SSL verify-full and verify-ca

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,35 @@ Since it uses protocol version 3, older versions probably also work but are not 
     in Crystal datatype. Therfore we provide a `PG::Interval` type that can be converted to
     `Time::Span` and `Time::MonthSpan`.
 
-# Authentication Methods
+## TLS Connections
+
+### SSL Mode
+
+Crystal-pg supports the `sslmode` parameter, with the values below:
+
+| Value         | Valid CA Required? | Matching hostname required? | TLS?                                    |
+|---------------|--------------------|-----------------------------|-----------------------------------------|
+| `disable`     | no                 | no                          | Does not negotiate TLS                  |
+| `allow`       | no                 | no                          | Negotiates TLS, falls back to plaintext |
+| `prefer`      | no                 | no                          | Negotiates TLS, falls back to plaintext |
+| `require`     | no                 | no                          | Negotiates TLS, exception otherwise     |
+| `verify-ca`   | yes                | no                          | Negotiates TLS, exception otherwise     |
+| `verify-full` | yes                | yes                         | Negotiates TLS, exception otherwise     |
+
+Note that `allow` and `prefer` are equivalent.
+
+SSL mode is not currently supported over UNIX sockets.
+
+### SSL Root Certificate
+
+This can be specified via the `sslrootcert` parameter, or the `PGSSLROOTCERT` environment variable.
+The parameter takes precedence over the environment variable. The value `system` does not load a
+custom cert and instead only uses the system's certificate store. If it is unset or the empty
+string, it falls back to either `%APPDATA%\postgresql\root.crt` on Windows or
+`~/.postgresql/root.crt` on Linux and Darwin. If the fallback file does not exist, only the system
+cert store is used.
+
+## Authentication Methods
 
 By default this driver will accept `scram-sha-256` and `md5`, as well as
 `trust`. However `cleartext` is disabled by default. You can control exactly

--- a/flake.nix
+++ b/flake.nix
@@ -20,15 +20,41 @@
           nativeBuildInputs = [ pkgs.openssl ];
           installPhase = ''
             mkdir $out
-            openssl req -new -nodes -text -out ca.csr -keyout ca-key.pem -subj "/CN=certificate-authority"
-            openssl x509 -req -in ca.csr -text -signkey ca-key.pem -out ca-cert.pem
-            openssl req -new -nodes -text -out server.csr -keyout server-key.pem -subj "/CN=pg-server"
-            openssl x509 -req -in server.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem
-            openssl req -new -nodes -text -out client.csr -keyout client-key.pem -subj "/CN=crystal_ssl"
-            openssl x509 -req -in client.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out client-cert.pem
 
-            # NOTE(2024-11-05): something broke with the newer openssl and client certs and the CA but I can't figure it out
-            # openssl verify -CAfile ca-cert.pem client-cert.pem
+            cat > ca.ext <<'EOF'
+            basicConstraints = critical, CA:TRUE
+            keyUsage = critical, keyCertSign, cRLSign
+            subjectKeyIdentifier = hash
+            EOF
+
+            cat > server.ext <<'EOF'
+            basicConstraints = critical, CA:FALSE
+            keyUsage = critical, digitalSignature, keyEncipherment
+            extendedKeyUsage = serverAuth
+            subjectAltName = IP:127.0.0.1
+            EOF
+
+            cat > client.ext <<'EOF'
+            basicConstraints = critical, CA:FALSE
+            keyUsage = critical, digitalSignature, keyEncipherment
+            extendedKeyUsage = clientAuth
+            EOF
+
+            openssl req -new -nodes -text -out ca.csr -keyout ca-key.pem -subj "/CN=certificate-authority"
+            openssl x509 -req -in ca.csr -text -signkey ca-key.pem -extfile ca.ext -days 3650 -out ca-cert.pem
+
+            # An unrelated CA, used only as a bogus sslrootcert for the negative specs.
+            openssl req -new -nodes -text -out other-ca.csr -keyout other-ca-key.pem -subj "/CN=other-certificate-authority"
+            openssl x509 -req -in other-ca.csr -text -signkey other-ca-key.pem -extfile ca.ext -days 3650 -out other-ca-cert.pem
+
+            openssl req -new -nodes -text -out server.csr -keyout server-key.pem -subj "/CN=pg-server"
+            openssl x509 -req -in server.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -extfile server.ext -days 3650 -out server-cert.pem
+
+            openssl req -new -nodes -text -out client.csr -keyout client-key.pem -subj "/CN=crystal_ssl"
+            openssl x509 -req -in client.csr -text -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -extfile client.ext -days 3650 -out client-cert.pem
+
+            openssl verify -CAfile ca-cert.pem server-cert.pem
+            openssl verify -CAfile ca-cert.pem client-cert.pem
 
             mv *.pem $out
           '';
@@ -71,6 +97,7 @@
           echo "
           local   all       postgres                     trust
           host    all       postgres       127.0.0.1/32  trust
+          host    all       postgres       ::1/128       trust
           host    all       crystal_md5    127.0.0.1/32  md5
           hostssl all       crystal_ssl    127.0.0.1/32  cert
           host    all       crystal_clear  127.0.0.1/32  password

--- a/spec/pq/conninfo_spec.cr
+++ b/spec/pq/conninfo_spec.cr
@@ -27,6 +27,18 @@ private def assert_ssl_params(ci)
   ci.sslcert.should eq("postgresql.crt")
   ci.sslkey.should eq("postgresql.key")
   ci.sslrootcert.should eq("root.crt")
+  ci.ssl_required?.should be_true
+  ci.verify_full?.should be_true
+end
+
+# The file and line parameters are to ensure that we report failures from where the helper was
+# called, not in the helper itself.
+private def assert_ssl_mode(mode : String, mode_symbol : Symbol, required : Bool, full : Bool, ca_only : Bool, file = __FILE__, line = __LINE__)
+  ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@host:5555/db?sslmode=#{mode}")
+  ci.sslmode.should eq(mode_symbol), file: file, line: line
+  ci.ssl_required?.should eq(required), file: file, line: line
+  ci.verify_full?.should eq(full), file: file, line: line
+  ci.verify_ca_only?.should eq(ca_only), file: file, line: line
 end
 
 describe PQ::ConnInfo, "parts" do
@@ -97,6 +109,57 @@ describe PQ::ConnInfo, ".from_conninfo_string" do
   it "parses an IPv6 host" do
     ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@[::1]:5555/db")
     ci.host.should eq("::1")
+  end
+
+  it "handles sslmodes" do
+    assert_ssl_mode "disable", :disable, false, false, false
+    assert_ssl_mode "allow", :allow, false, false, false
+    assert_ssl_mode "prefer", :prefer, false, false, false
+    assert_ssl_mode "require", :require, true, false, false
+    assert_ssl_mode "verify-ca", :"verify-ca", true, false, true
+    assert_ssl_mode "verify-full", :"verify-full", true, true, false
+  end
+
+  it "uses sslrootcert from env" do
+    env_var_bubble do
+      ENV["PGSSLROOTCERT"] = "/env/root.crt"
+      ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@host:5555/db")
+      ci.resolved_sslrootcert.should eq "/env/root.crt"
+    end
+  end
+
+  it "explicit sslrootcert beats env" do
+    env_var_bubble do
+      ENV["PGSSLROOTCERT"] = "/env/root.crt"
+      ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@host:5555/db?sslmode=require&sslrootcert=/explicit/root.crt")
+      ci.resolved_sslrootcert.should eq "/explicit/root.crt"
+    end
+  end
+
+  it "accepts sslrootcert=system param" do
+    env_var_bubble do
+      ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@host:5555/db?sslmode=require&sslrootcert=system")
+      ci.resolved_sslrootcert.should be_nil
+      ci.sslrootcert.should eq "system"
+    end
+  end
+
+  it "accepts sslrootcert=system from env" do
+    env_var_bubble do
+      ENV["PGSSLROOTCERT"] = "system"
+      ci = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@host:5555/db?sslmode=require")
+      ci.resolved_sslrootcert.should be_nil
+      ci.sslrootcert.should be_nil
+    end
+  end
+
+  it "handles empty PGSSLROOTCERT env value" do
+    env_var_bubble do
+      value_without_env_var = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@host:5555/db?sslmode=require").resolved_sslrootcert
+      ENV["PGSSLROOTCERT"] = ""
+      value_with_empty_env_var = PQ::ConnInfo.from_conninfo_string("postgres://user:pass@host:5555/db?sslmode=require").resolved_sslrootcert
+      value_without_env_var.should eq value_with_empty_env_var
+    end
   end
 
   it "auth_methods" do

--- a/spec/pq/ssl_spec.cr
+++ b/spec/pq/ssl_spec.cr
@@ -1,0 +1,65 @@
+require "../spec_helper"
+
+# Specs using the certs from the nix test harness against a server with
+# ssl=on.
+#
+# Test both 127.0.0.1 and localhost, because only one is in the cert,
+# so it lets us distinguish verify-ca from verify-full.
+
+SSL_PORT     = ENV["PGPORT"]? || "5432"
+SSL_DATABASE = PG_DB.query_one("select current_database()", &.read)
+
+private def ssl_url(host, sslmode, sslrootcert)
+  "postgres://postgres@#{host}:#{SSL_PORT}/#{SSL_DATABASE}?sslmode=#{sslmode}&sslrootcert=#{sslrootcert}"
+end
+
+if certs = ENV["CRYSTAL_PG_CERT_DIR"]?
+  ca = Path[certs, "ca-cert.pem"].to_s
+  untrusted_ca = Path[certs, "other-ca-cert.pem"].to_s
+
+  describe PQ::Connection, "sslmode=verify-full" do
+    it "connects when the certificate is trusted and names the host" do
+      DB.open(ssl_url("127.0.0.1", "verify-full", ca)) do |db|
+        db.query_one("select 1", &.read).should eq(1)
+        db.query_one("select ssl from pg_stat_ssl where pid = pg_backend_pid()", &.read).should be_true
+      end
+    end
+
+    it "refuses a certificate that does not name the host" do
+      exc = expect_raises(DB::ConnectionRefused) do
+        DB.open(ssl_url("localhost", "verify-full", ca)) { }
+      end
+      exc.cause.try(&.message).to_s.should contain "certificate verify failed"
+    end
+
+    it "refuses a certificate signed by an untrusted CA" do
+      exc = expect_raises(DB::ConnectionRefused) do
+        DB.open(ssl_url("127.0.0.1", "verify-full", untrusted_ca)) { }
+      end
+      exc.cause.try(&.message).to_s.should contain "certificate verify failed"
+    end
+  end
+
+  describe PQ::Connection, "sslmode=verify-ca" do
+    it "connects when the certificate is trusted but does not name the host" do
+      DB.open(ssl_url("localhost", "verify-ca", ca)) do |db|
+        db.query_one("select 1", &.read).should eq(1)
+        db.query_one("select ssl from pg_stat_ssl where pid = pg_backend_pid()", &.read).should be_true
+      end
+    end
+
+    it "connects when the certificate is trusted and names the host" do
+      DB.open(ssl_url("127.0.0.1", "verify-ca", ca)) do |db|
+        db.query_one("select 1", &.read).should eq(1)
+        db.query_one("select ssl from pg_stat_ssl where pid = pg_backend_pid()", &.read).should be_true
+      end
+    end
+
+    it "refuses a certificate signed by an untrusted CA" do
+      exc = expect_raises(DB::ConnectionRefused) do
+        DB.open(ssl_url("127.0.0.1", "verify-ca", untrusted_ca)) { }
+      end
+      exc.cause.try(&.message).to_s.should contain "certificate verify failed"
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -62,7 +62,7 @@ end
 
 def env_var_bubble(&)
   orig_vals = Hash(String, String).new
-  vars = ["PGDATABASE", "PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGPASSFILE"]
+  vars = ["PGDATABASE", "PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGPASSFILE", "PGAPPNAME"]
   begin
     vars.each do |var|
       if ENV.has_key?(var)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -62,7 +62,7 @@ end
 
 def env_var_bubble(&)
   orig_vals = Hash(String, String).new
-  vars = ["PGDATABASE", "PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGPASSFILE", "PGAPPNAME"]
+  vars = ["PGDATABASE", "PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGPASSFILE", "PGAPPNAME", "PGSSLROOTCERT"]
   begin
     vars.each do |var|
       if ENV.has_key?(var)

--- a/src/ext/openssl.cr
+++ b/src/ext/openssl.cr
@@ -82,3 +82,10 @@ end
     fun x509_digest = X509_digest(x509 : X509, evp_md : EVP_MD, hash : UInt8*, len : Int32*) : Int32
   end
 {% end %}
+
+# Needed to be able to support the ssl modes (verify-full, verify-ca, etc)
+{% unless LibCrypto.has_method?(:x509_store_ctx_get_error) %}
+  lib LibCrypto
+    fun x509_store_ctx_get_error = X509_STORE_CTX_get_error(ctx : X509_STORE_CTX) : Int32
+  end
+{% end %}

--- a/src/pq/connection.cr
+++ b/src/pq/connection.cr
@@ -13,6 +13,24 @@ module PQ
 
   # :nodoc:
   class Connection
+    # Error codes we care about for sslmode=verify-ca
+
+    X509_V_ERR_HOSTNAME_MISMATCH   = 62
+    X509_V_ERR_IP_ADDRESS_MISMATCH = 64
+
+    # A bound callback to use when verifying the SSL connection. Used to allow verify-ca to
+    # function as intended.
+    VERIFY_CA_CALLBACK = ->(preverify_ok : LibC::Int, ctx : LibCrypto::X509_STORE_CTX) do
+      return preverify_ok if preverify_ok == 1
+
+      case LibCrypto.x509_store_ctx_get_error(ctx)
+      when X509_V_ERR_HOSTNAME_MISMATCH, X509_V_ERR_IP_ADDRESS_MISMATCH
+        1
+      else
+        0
+      end
+    end
+
     getter soc : UNIXSocket | TCPSocket | OpenSSL::SSL::Socket::Client
     getter server_parameters = Hash(String, String).new
     getter conninfo : ConnInfo
@@ -49,22 +67,31 @@ module PQ
 
       if process_ssl_message
         ctx = OpenSSL::SSL::Context::Client.new
-        ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE # currently emulating sslmode 'require' not verify_ca or verify_full
         if sslcert = @conninfo.sslcert
           ctx.certificate_chain = sslcert
         end
         if sslkey = @conninfo.sslkey
           ctx.private_key = sslkey
         end
-        if sslrootcert = @conninfo.sslrootcert
+        if sslrootcert = @conninfo.resolved_sslrootcert
           ctx.ca_certificates = sslrootcert
         end
+
+        # Set the verify mode. For verify-ca, we need a custom callback that ignores hostname
+        # or ip mismatches, for verify-full we need the default verification, and otherwise
+        # we set the mode to NONE for allow/prefer
+        if @conninfo.verify_ca_only?
+          LibSSL.ssl_ctx_set_verify(ctx, OpenSSL::SSL::VerifyMode::PEER, VERIFY_CA_CALLBACK)
+        elsif !@conninfo.verify_full?
+          ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+        end
+
         @soc = OpenSSL::SSL::Socket::Client.new(@soc, context: ctx, sync_close: true, hostname: @conninfo.host)
       end
 
-      if @conninfo.sslmode == :require && !@soc.is_a?(OpenSSL::SSL::Socket::Client)
+      if @conninfo.ssl_required? && !@soc.is_a?(OpenSSL::SSL::Socket::Client)
         close
-        raise ConnectionError.new("sslmode=require and server did not establish SSL")
+        raise ConnectionError.new("sslmode=#{@conninfo.sslmode} and server did not establish SSL")
       end
     end
 

--- a/src/pq/conninfo.cr
+++ b/src/pq/conninfo.cr
@@ -33,6 +33,8 @@ module PQ
     getter sslkey : String?
 
     # The sslrootcert. Optional.
+    # This only reports what the DSN provides; use `#resolved_sslrootcert` if you need the path
+    # in use, if any.
     getter sslrootcert : String?
 
     # The application name. Optional (defaults to "crystal").
@@ -99,6 +101,53 @@ module PQ
       params.each do |key, value|
         handle_sslparam(key, value)
       end
+    end
+
+    # Is SSL required?
+    def ssl_required?
+      case sslmode
+      when :require, :"verify-ca", :"verify-full"
+        true
+      else
+        false
+      end
+    end
+
+    # Test for full SSL verification
+    def verify_full?
+      sslmode == :"verify-full"
+    end
+
+    # Test for only verifying SSL CA
+    def verify_ca_only?
+      sslmode == :"verify-ca"
+    end
+
+    # Resolve the SSL root cert
+    def resolved_sslrootcert : String?
+      # Use a specified sslrootcert if there is one
+      resolved = sslrootcert.presence || ENV["PGSSLROOTCERT"]?.presence || default_sslrootcert
+
+      # Use the system cert store
+      resolved = nil if resolved == "system"
+
+      resolved
+    end
+
+    # The default sslrootcert, if it exists
+    private def default_sslrootcert : String?
+      path = {% if flag?(:windows) %}
+               if ENV["APPDATA"]?
+                 Path[ENV["APPDATA"], "postgresql", "root.crt"]
+               else
+                 nil
+               end
+             {% else %}
+               Path["~/.postgresql/root.crt"].expand(home: true)
+             {% end %}
+      return unless path
+
+      File.exists?(path) ? path.to_s : nil
     end
 
     private def handle_sslparam(key : String, value : String)


### PR DESCRIPTION
Changes `sslmode=verify-full` and `sslmode=verify-ca` to no longer accept plaintext connections--only `sslmode-require` did so before.

Adds a method `#ssl_required?` to answer whether SSL must be negotiated.

Adds a method `#resolved_sslrootcert` to get the path to the SSL root certificate; this is determined from `$PGSSLROOTCERT` and/or the `sslrootcert` parameter, and defaults to `~/.postgres/root.crt` on Linux/Darwin, or `%APPDATA%/postgresql/root.crt` on Windows.